### PR TITLE
Transaction-safe option.

### DIFF
--- a/config/default/LtiUserService.conf.php
+++ b/config/default/LtiUserService.conf.php
@@ -1,3 +1,4 @@
 <?php
-
-return new \oat\taoLti\models\classes\user\OntologyLtiUserService();
+return new \oat\taoLti\models\classes\user\OntologyLtiUserService([
+    'transaction-safe' => false
+]);

--- a/config/default/LtiUserService.conf.php
+++ b/config/default/LtiUserService.conf.php
@@ -1,4 +1,5 @@
 <?php
 return new \oat\taoLti\models\classes\user\OntologyLtiUserService([
-    'transaction-safe' => false
+    'transaction-safe' => false,
+    'transaction-safe-retry' => 1
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
 	'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '3.4.3',
+    'version' => '3.5.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
        'generis' => '>=5.4.0',

--- a/manifest.php
+++ b/manifest.php
@@ -38,6 +38,7 @@ return array(
     'version' => '3.4.3',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
+       'generis' => '5.4.0',
 	   'tao' => '>=10.8.0'
 	),
 	'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return array(
     'version' => '3.4.3',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
-       'generis' => '5.4.0',
+       'generis' => '>=5.4.0',
 	   'tao' => '>=10.8.0'
 	),
 	'models' => array(

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -59,7 +59,7 @@ class OntologyLtiUserService extends LtiUserService
         $transactionSafe = $this->getOption(self::OPTION_TRANSACTION_SAFE);
         
         if (!$dataModel instanceof \core_kernel_persistence_smoothsql_SmoothModel || !$transactionSafe) {
-            // Non-transaction safe approach.
+            // Non-transaction safe approach (default).
             $taoUser = $this->findUser($launchData);
             if (is_null($taoUser)) {
                 $taoUser = $this->spawnUser($launchData);

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -66,6 +66,8 @@ class OntologyLtiUserService extends LtiUserService
             if (is_null($taoUser)) {
                 $taoUser = $this->spawnUser($launchData);
             }
+            
+            return $taoUser;
         } else {
             // Transaction safe approach.
             $platform = $dataModel->getPersistence()->getPlatform();            

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -93,7 +93,6 @@ class OntologyLtiUserService extends LtiUserService
                     \common_Logger::d('SQL Serialization Failure occured in ' . __CLASS__ . '::' . __LINE__ . ' while finding or spawing LTI Ontology user. Retried ' . $retry . ' times.');
                     $retry++;
                 } catch (\Exception $e) {
-                    \common_Logger::i(get_class($e));
                     $platform->rollback();
                     throw new \taoLti_models_classes_LtiException('LTI Ontology user could not be created. Process had to be rolled back.', 0, $e);
                 }

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -68,6 +68,8 @@ class OntologyLtiUserService extends LtiUserService
             // Transaction safe approach.
             $platform = $dataModel->getPersistence()->getPlatform();
             $platform->beginTransaction();
+            
+            // As the following instructions produce a Critical Section, we need SERIALIZABLE SQL Isolation Level.
             $platform->setTransactionIsolation(\common_persistence_sql_Platform::TRANSACTION_SERIALIZABLE);
             
             try {

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -248,7 +248,7 @@ class OntologyLtiUserService extends LtiUserService
         return $ltiUser;
     }
     
-    public function getRetryOption()
+    private function getRetryOption()
     {
         $retryOption = $this->getOption(self::OPTION_TRANSACTION_SAFE_RETRY);
         

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -86,7 +86,7 @@ class taoLti_scripts_update_Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('3.4.0');
         }
-        $this->skip('3.4.0', '3.4.3');
+        $this->skip('3.4.0', '3.5.0');
 
     }
 }

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -87,13 +87,15 @@ class taoLti_scripts_update_Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.4.0');
         }
         
-        if ($this->isVersion('3.4.0')) {
+        $this->skip('3.4.0', '3.4.3');
+        
+        if ($this->isVersion('3.4.3')) {
             $userService = $this->getServiceManager()->get(LtiUserService::SERVICE_ID);
             if ($userService instanceof OntologyLtiUserService) {
                 $userService->setOption(OntologyLtiUserService::OPTION_TRANSACTION_SAFE, false);
                 $userService->setOption(OntologyLtiUserService::OPTION_TRANSACTION_SAFE_RETRY, 1);
             }
-            $this->getServiceManager()->register(LtiUserService::SERVICE_ID, $service);
+            $this->getServiceManager()->register(LtiUserService::SERVICE_ID, $userService);
             
             $this->setVersion('3.5.0');
         }

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -91,8 +91,9 @@ class taoLti_scripts_update_Updater extends \common_ext_ExtensionUpdater
             $userService = $this->getServiceManager()->get(LtiUserService::SERVICE_ID);
             if ($userService instanceof OntologyLtiUserService) {
                 $userService->setOption(OntologyLtiUserService::OPTION_TRANSACTION_SAFE, false);
-                $userService->setOption(OPTION_TRANSACTION_SAFE_RETRY, 1);
+                $userService->setOption(OntologyLtiUserService::OPTION_TRANSACTION_SAFE_RETRY, 1);
             }
+            $this->getServiceManager()->register(LtiUserService::SERVICE_ID, $service);
             
             $this->setVersion('3.5.0');
         }

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -86,7 +86,15 @@ class taoLti_scripts_update_Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('3.4.0');
         }
-        $this->skip('3.4.0', '3.5.0');
-
+        
+        if ($this->isVersion('3.4.0')) {
+            $userService = $this->getServiceManager()->get(LtiUserService::SERVICE_ID);
+            if ($userService instanceof OntologyLtiUserService) {
+                $userService->setOption(OntologyLtiUserService::OPTION_TRANSACTION_SAFE, false);
+                $userService->setOption(OPTION_TRANSACTION_SAFE_RETRY, 1);
+            }
+            
+            $this->setVersion('3.5.0');
+        }
     }
 }


### PR DESCRIPTION
**DEPENDS ON https://github.com/oat-sa/generis/pull/415**

You can turn on the `transaction-safe` mode for the Ontology Implementation by changing the value of the `transaction-safe` parameter in `/config/taoLti/LtiUserService.conf.php` e.g. 

```php
return new oat\taoLti\models\classes\user\OntologyLtiUserService(array(
    'transaction-safe' => true,
    'transaction-safe-retry' => 1
));

```