### PR TITLE
Fix/tao 8156/updated jquery ui css path

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '9.2.0',
+    'version' => '9.2.1',
       'author' => 'Open Assessment Technologies SA',
       'requires' => array(
         'generis' => '>=9.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -221,5 +221,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->unregister(ProviderService::SERVICE_ID);
             $this->setVersion('9.2.0');
         }
+
+        $this->skip('9.2.0', '9.2.1');
     }
 }

--- a/views/templates/error.tpl
+++ b/views/templates/error.tpl
@@ -7,7 +7,7 @@ use oat\tao\helpers\Template;
 <head>
 	<title><?= __('Server Error')?></title>
 	<link rel="stylesheet" type="text/css" href="<?= Template::css('reset.css','tao') ?>" />
-	<link rel="stylesheet" type="text/css" href="<?= Template::css('custom-theme/jquery-ui-1.8.22.custom.css','tao') ?>" />
+	<link rel="stylesheet" type="text/css" href="<?= Template::css('custom-theme/jquery-ui-1.9.2.custom.css','tao') ?>" />
 	<link rel="stylesheet" type="text/css" href="<?= Template::css('errors.css','tao') ?>" />
 	<link rel="stylesheet" type="text/css" href="<?= Template::css('userError.css','tao') ?>" />
 </head>


### PR DESCRIPTION
task https://oat-sa.atlassian.net/browse/TAO-8156

- replaced `jquery-ui-1.8.22` which is not exists anymore by `jquery-ui-1.9.2` (new version of library)