### PR TITLE
added LtiUser events (create and update)

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '10.0.0',
+    'version' => '10.1.0',
       'author' => 'Open Assessment Technologies SA',
       'requires' => array(
         'generis' => '>=11.2.0',

--- a/models/classes/user/KvLtiUserService.php
+++ b/models/classes/user/KvLtiUserService.php
@@ -68,6 +68,7 @@ class KvLtiUserService extends LtiUserService
     protected function updateUser(LtiUserInterface $user, LtiLaunchData $ltiContext)
     {
         $technicalId = self::LTI_USER . $ltiContext->getUserID() . $ltiContext->getLtiConsumer()->getUri();
+        $isUpdate = $this->getPersistence()->exists($technicalId);
 
         if (empty($user->getIdentifier())) {
             $user->setIdentifier($technicalId);
@@ -83,6 +84,12 @@ class KvLtiUserService extends LtiUserService
 
         $this->getPersistence()->set($technicalId, json_encode($data));
         $this->getPersistence()->set(self::LTI_USER_LOOKUP . $taoUserId, $technicalId);
+
+        if ($isUpdate) {
+            $this->userUpdatedEvent($technicalId);
+        } else {
+            $this->userCreatedEvent($technicalId);
+        }
     }
 
     /**

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -67,13 +67,17 @@ class OntologyLtiUserService extends LtiUserService
                 GenerisRdf::PROPERTY_USER_ROLES,
             ]);
 
+            $hasUpdates = false;
             foreach ($properties as $key => $values){
-                if ($values !== $user->getPropertyValues($key)){
+                if ($values != $user->getPropertyValues($key)){
                     $userResource->editPropertyValues(new \core_kernel_classes_Property($key), $user->getPropertyValues($key));
+                    $hasUpdates = true;
                 }
             }
 
-            $this->userUpdatedEvent($userResource->getUri());
+            if ($hasUpdates) {
+                $this->userUpdatedEvent($userResource->getUri());
+            }
         } else {
             $class = new \core_kernel_classes_Class(self::CLASS_LTI_USER);
 

--- a/models/classes/user/OntologyLtiUserService.php
+++ b/models/classes/user/OntologyLtiUserService.php
@@ -41,7 +41,7 @@ class OntologyLtiUserService extends LtiUserService
     const CLASS_LTI_USER = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIUser';
 
     const OPTION_TRANSACTION_SAFE = 'transaction-safe';
-    
+
     const OPTION_TRANSACTION_SAFE_RETRY = 'transaction-safe-retry';
 
     /**
@@ -68,14 +68,14 @@ class OntologyLtiUserService extends LtiUserService
             ]);
 
             foreach ($properties as $key => $values){
-                if ($values != $user->getPropertyValues($key)){
+                if ($values !== $user->getPropertyValues($key)){
                     $userResource->editPropertyValues(new \core_kernel_classes_Property($key), $user->getPropertyValues($key));
                 }
-
             }
+
+            $this->userUpdatedEvent($userResource->getUri());
         } else {
             $class = new \core_kernel_classes_Class(self::CLASS_LTI_USER);
-
 
             $props = array(
                 self::PROPERTY_USER_LTIKEY => $ltiContext->getUserID(),
@@ -90,6 +90,7 @@ class OntologyLtiUserService extends LtiUserService
 
             $userResource = $class->createInstanceWithProperties($props);
             \common_Logger::i('added User ' . $userResource->getLabel());
+            $this->userCreatedEvent($userResource->getUri());
         }
         $user->setIdentifier($userResource->getUri());
     }
@@ -123,11 +124,11 @@ class OntologyLtiUserService extends LtiUserService
 
     }
 
-    
+
     private function getRetryOption()
     {
         $retryOption = $this->getOption(self::OPTION_TRANSACTION_SAFE_RETRY);
-        
+
         // Arbitrary default is 1.
         return ($retryOption) ? $retryOption : 1;
     }

--- a/models/classes/user/events/LtiUserCreatedEvent.php
+++ b/models/classes/user/events/LtiUserCreatedEvent.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ *
+ * @author Oleksandr Zagovorychev <zagovorichev@1pt.com>
+ */
+
+namespace oat\taoLti\models\classes\user\events;
+
+
+class LtiUserCreatedEvent extends LtiUserEvent
+{
+    const EVENT_NAME = __CLASS__;
+
+    public function getName()
+    {
+        return self::EVENT_NAME;
+    }
+}

--- a/models/classes/user/events/LtiUserEvent.php
+++ b/models/classes/user/events/LtiUserEvent.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ *
+ * @author Oleksandr Zagovorychev <zagovorichev@gmail.com>
+ */
+
+namespace oat\taoLti\models\classes\user\events;
+
+
+use oat\oatbox\event\Event;
+
+abstract class LtiUserEvent  implements Event
+{
+    private $userId;
+
+    public function __construct($userId)
+    {
+        $this->userId = $userId;
+    }
+
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+}

--- a/models/classes/user/events/LtiUserUpdatedEvent.php
+++ b/models/classes/user/events/LtiUserUpdatedEvent.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ *
+ * @author Oleksandr Zagovorychev <zagovorichev@gmail.com>
+ */
+
+namespace oat\taoLti\models\classes\user\events;
+
+
+class LtiUserUpdatedEvent extends LtiUserEvent
+{
+    const EVENT_NAME = __CLASS__;
+
+    public function getName()
+    {
+        return self::EVENT_NAME;
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -222,6 +222,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('9.2.0');
         }
 
-        $this->skip('9.2.0', '10.0.0');
+        $this->skip('9.2.0', '10.1.0');
     }
 }


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TAO-8585
 
New events added to have a possibility to listen when lti user changed:
- added LtiUserUpdatedEvent
- added LtiUserCreatedEvent
 
#### How to test

You can test it with the taoSyncClient extension (https://github.com/oat-sa/extension-tao-sync-client/tree/develop)
taoSyncClient creates `sync_client_queue` table and add new rows on lti user update action