### PR TITLE
Fix/nex 256/fixed updater and installer

### DIFF
--- a/config/default/LtiProviderService.conf.php
+++ b/config/default/LtiProviderService.conf.php
@@ -1,9 +1,12 @@
 <?php
+
+use oat\taoLti\models\classes\LtiProvider\ConfigurableLtiProviderRepository;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
 use oat\taoLti\models\classes\LtiProvider\RdfLtiProviderRepository;
 
 return new LtiProviderService([
     LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
         new RdfLtiProviderRepository(),
+        new ConfigurableLtiProviderRepository(),
     ]
 ]);

--- a/config/default/LtiProviderService.conf.php
+++ b/config/default/LtiProviderService.conf.php
@@ -1,12 +1,10 @@
 <?php
 
-use oat\taoLti\models\classes\LtiProvider\ConfigurableLtiProviderRepository;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
 use oat\taoLti\models\classes\LtiProvider\RdfLtiProviderRepository;
 
 return new LtiProviderService([
     LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
         new RdfLtiProviderRepository(),
-        new ConfigurableLtiProviderRepository(),
     ]
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '10.3.0',
+    'version' => '10.3.1',
       'author' => 'Open Assessment Technologies SA',
       'requires' => array(
         'generis' => '>=12.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -228,15 +228,25 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('9.2.0', '10.2.0');
 
         if ($this->isVersion('10.2.0')) {
-            /** @var LtiProviderService $ltiProviderService */
-            $ltiProviderService = $this->getServiceManager()->get(LtiProviderService::SERVICE_ID);
-            $ltiProviderService->setOption($ltiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS, [
-                new RdfLtiProviderRepository(),
-                new ConfigurableLtiProviderRepository(),
-            ]);
+            if ($this->getServiceManager()->has(LtiProviderService::SERVICE_ID)) {
+                /** @var LtiProviderService $ltiProviderService */
+                $ltiProviderService = $this->getServiceManager()->get(LtiProviderService::SERVICE_ID);
+                $ltiProviderService->setOption($ltiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS, [
+                    new RdfLtiProviderRepository(),
+                    new ConfigurableLtiProviderRepository(),
+                ]);
+            } else {
+                $ltiProviderService = new LtiProviderService([
+                    LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
+                        new RdfLtiProviderRepository(),
+                        new ConfigurableLtiProviderRepository(),
+                    ]
+                ]);
+            }
             $this->getServiceManager()->register(LtiProviderService::SERVICE_ID, $ltiProviderService);
-
             $this->setVersion('10.3.0');
         }
+
+        $this->skip('10.3.0', '10.3.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -34,14 +34,11 @@ use oat\taoLti\models\classes\LaunchData\Validator\Lti11LaunchDataValidator;
 use oat\taoLti\models\classes\LaunchData\Validator\LtiValidatorService;
 use oat\taoLti\models\classes\LtiAuthAdapter;
 use oat\taoLti\models\classes\LtiException;
-use oat\taoLti\models\classes\LtiProvider\ConfigurableLtiProviderRepository;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
 use oat\taoLti\models\classes\LtiProvider\RdfLtiProviderRepository;
-use oat\taoLti\models\classes\ProviderService;
 use oat\taoLti\models\classes\ResourceLink\LinkService;
 use oat\taoLti\models\classes\ResourceLink\OntologyLink;
 use oat\taoLti\models\classes\user\LtiUserFactoryService;
-use oat\taoLti\models\classes\user\LtiUserHelper;
 use oat\taoLti\models\classes\user\LtiUserService;
 use oat\taoLti\models\classes\user\OntologyLtiUserService;
 use oat\taoLti\models\classes\user\UserService;
@@ -233,13 +230,11 @@ class Updater extends \common_ext_ExtensionUpdater
                 $ltiProviderService = $this->getServiceManager()->get(LtiProviderService::SERVICE_ID);
                 $ltiProviderService->setOption($ltiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS, [
                     new RdfLtiProviderRepository(),
-                    new ConfigurableLtiProviderRepository(),
                 ]);
             } else {
                 $ltiProviderService = new LtiProviderService([
                     LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
                         new RdfLtiProviderRepository(),
-                        new ConfigurableLtiProviderRepository(),
                     ]
                 ]);
             }


### PR DESCRIPTION
fix for https://oat-sa.atlassian.net/browse/NEX-256

1. The version of TAO after the installation has to be equal to the version of TAO after Update (in this case - it's a different configuration of the service)
2. Fixed updater - if service new it has to be created, service can't be updated if it does not exist.