### PR TITLE
Fix/label in lockid

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '11.3.0',
+    'version' => '11.3.1',
       'author' => 'Open Assessment Technologies SA',
       'requires' => [
         'generis' => '>=12.5.0',

--- a/models/classes/user/LtiUserService.php
+++ b/models/classes/user/LtiUserService.php
@@ -65,7 +65,7 @@ abstract class LtiUserService extends ConfigurableService
      */
     public function findOrSpawnUser(LtiLaunchData $launchData)
     {
-        $lock = $this->createLock(__METHOD__ . $launchData->getUserID() . $launchData->getLtiConsumer(), 30);
+        $lock = $this->createLock(__METHOD__ . $launchData->getUserID() . $launchData->getLtiConsumer()->getUri(), 30);
         $lock->acquire(true);
 
         try {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -265,6 +265,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('11.0.0');
         }
 
-        $this->skip('11.0.0', '11.3.0');
+        $this->skip('11.0.0', '11.3.1');
     }
 }


### PR DESCRIPTION
Lock id should be based on consumer id, but here we triggered the _toString() of the resource which triggered an unnecessary query to retrieve the label of the resource.