### PR TITLE
TBD-8 post-merge quickfix of updater script

### DIFF
--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -259,7 +259,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(
                 LisOauthService::SERVICE_ID,
                 new LisOauthService([
-                    LisOauthService::OPTION_DATASTORE => new LisOauthDataStore([
+                    LisOauthService::OPTION_DATA_STORE => new LisOauthDataStore([
                         LisOauthDataStore::OPTION_NONCE_STORE => new NoNonce()
                     ])
                 ])


### PR DESCRIPTION
- TBD-8 fix(updater): replace usage of `OauthService::OPTION_DATASTORE` with a proper `OPTION_DATA_STORE` in `Updater` script

That line wasn't considered to be a conflicting one of course, as it was just added in one of the recent PRs.