### PR TITLE
Fix/lti user without first name

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '11.7.1',
+    'version' => '11.7.2',
       'author' => 'Open Assessment Technologies SA',
       'requires' => [
         'generis' => '>=12.15.0',

--- a/models/classes/user/LtiUser.php
+++ b/models/classes/user/LtiUser.php
@@ -180,10 +180,10 @@ class LtiUser extends \common_user_User implements ServiceLocatorAwareInterface,
                 $returnValue = $this->taoRoles;
                 break;
             case GenerisRdf::PROPERTY_USER_FIRSTNAME:
-                $returnValue = [$this->firstname];
+                $returnValue = $this->firstname !== null ? [$this->firstname] : '';
                 break;
             case GenerisRdf::PROPERTY_USER_LASTNAME:
-                $returnValue = [$this->lastname];
+                $returnValue = $this->lastname !== null ? [$this->lastname] : '';
                 break;
             case OntologyRdfs::RDFS_LABEL:
                 $returnValue = [$this->label];

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -278,6 +278,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('11.6.0');
         }
 
-        $this->skip('11.6.0', '11.7.1');
+        $this->skip('11.6.0', '11.7.2');
     }
 }


### PR DESCRIPTION
https://github.com/oat-sa/generis/pull/779

The fix for
`Fatal error: Uncaught TypeError: Argument 4 passed to core_kernel_classes_Triple::createTriple() must be of the type string, null given, called in /generis/core/kernel/persistence/smoothsql/class.Resource.php on line 642 and defined in /generis/core/kernel/classes/class.Triple.php:106
`
How to reproduce:
Start a Lti session without `first_name` or `last_name` for a TT