### PR TITLE
added lockout subservice to LisOauthService

### DIFF
--- a/config/default/LisOauthService.conf.php
+++ b/config/default/LisOauthService.conf.php
@@ -3,5 +3,6 @@
 return new oat\taoLti\models\classes\Lis\LisOauthService([
     'store' => new oat\taoLti\models\classes\Lis\LisOauthDataStore([
         'nonce_store' => new oat\tao\model\oauth\nonce\NoNonce()
-    ])
+    ]),
+    'lockout' => new oat\tao\model\oauth\lockout\NoLockout(),
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '11.8.0',
+    'version' => '11.8.1',
       'author' => 'Open Assessment Technologies SA',
       'requires' => [
         'generis' => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -25,7 +25,9 @@ namespace oat\taoLti\scripts\update;
 use common_Exception;
 use common_ext_ExtensionsManager;
 use oat\tao\model\mvc\error\ExceptionInterpreterService;
+use oat\tao\model\oauth\lockout\NoLockout;
 use oat\tao\model\oauth\nonce\NoNonce;
+use oat\tao\model\oauth\OauthService;
 use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoLti\models\classes\ConsumerService;
 use oat\taoLti\models\classes\CookieVerifyService;
@@ -279,5 +281,13 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('11.6.0', '11.8.0');
+
+        if ($this->isVersion('11.8.0')) {
+            $lisOauthService = $this->getServiceManager()->get(LisOauthService::SERVICE_ID);
+            $lisOauthService->setOption(OauthService::OPTION_LOCKOUT_SERVICE, new NoLockout());
+            $this->getServiceManager()->register(LisOauthService::SERVICE_ID, $lisOauthService);
+
+            $this->setVersion('11.8.1');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -284,8 +284,11 @@ class Updater extends \common_ext_ExtensionUpdater
 
         if ($this->isVersion('11.8.0')) {
             $lisOauthService = $this->getServiceManager()->get(LisOauthService::SERVICE_ID);
-            $lisOauthService->setOption(OauthService::OPTION_LOCKOUT_SERVICE, new NoLockout());
-            $this->getServiceManager()->register(LisOauthService::SERVICE_ID, $lisOauthService);
+
+            if (!$lisOauthService->hasOption(OauthService::OPTION_LOCKOUT_SERVICE)) {
+                $lisOauthService->setOption(OauthService::OPTION_LOCKOUT_SERVICE, new NoLockout());
+                $this->getServiceManager()->register(LisOauthService::SERVICE_ID, $lisOauthService);
+            }
 
             $this->setVersion('11.8.1');
         }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-1228

This PR fixes an issue in LisOauthService that the `lockout` sub-service was not defined which is inherited from `OauthService`.