### PR TITLE
Feature/nex 1534/jwks service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
+        "ext-openssl": "*",
         "oat-sa/lib-lti1p3-core": "^2.0"
     },
     "autoload" : {

--- a/config/default/KeyChainGenerator.conf.php
+++ b/config/default/KeyChainGenerator.conf.php
@@ -1,0 +1,13 @@
+<?php
+
+use oat\taoLti\models\classes\Platform\Service\CachedKeyChainGenerator;
+
+return new CachedKeyChainGenerator(
+    [
+        'sslConfig' => [
+            'digest_alg' => 'sha256',
+            'private_key_bits' => 4096,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]
+    ]
+);

--- a/manifest.php
+++ b/manifest.php
@@ -23,6 +23,7 @@ use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
 use oat\taoLti\controller\CookieUtils;
 use oat\taoLti\controller\Security;
+use oat\taoLti\scripts\install\GenerateKeys;
 use oat\taoLti\scripts\install\InstallServices;
 use oat\taoLti\scripts\update\Updater;
 
@@ -37,7 +38,7 @@ return [
     'label' => 'LTI library',
     'description' => 'TAO LTI library and helpers',
     'license' => 'GPL-2.0',
-    'version' => '11.14.0',
+    'version' => '11.15.0',
       'author' => 'Open Assessment Technologies SA',
       'requires' => [
         'generis' => '>=12.15.0',
@@ -59,7 +60,8 @@ return [
             $extpath . 'install/ontology/ltiroles_membership.rdf'
         ],
         'php' => [
-            InstallServices::class
+            InstallServices::class,
+            GenerateKeys::class
         ]
     ],
     'update' => Updater::class,

--- a/migrations/Version202008131228163772_taoLti.php
+++ b/migrations/Version202008131228163772_taoLti.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
+use oat\taoLti\models\classes\Platform\Service\KeyChainGeneratorInterface;
+
+final class Version202008131228163772_taoLti extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Will generate keyChain and store in persistence';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->getKeyChainGenerator()->generate();
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+
+    /**
+     * @return KeyChainGeneratorInterface
+     */
+    private function getKeyChainGenerator(): KeyChainGeneratorInterface
+    {
+        return $this->getServiceLocator()->get(KeyChainGenerator::class);
+    }
+}

--- a/migrations/Version202008131228163772_taoLti.php
+++ b/migrations/Version202008131228163772_taoLti.php
@@ -26,9 +26,6 @@ final class Version202008131228163772_taoLti extends AbstractMigration
     {
     }
 
-    /**
-     * @return KeyChainGeneratorInterface
-     */
     private function getKeyChainGenerator(): KeyChainGeneratorInterface
     {
         return $this->getServiceLocator()->get(CachedKeyChainGenerator::class);

--- a/migrations/Version202008131228163772_taoLti.php
+++ b/migrations/Version202008131228163772_taoLti.php
@@ -6,7 +6,7 @@ namespace oat\taoLti\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
-use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
+use oat\taoLti\models\classes\Platform\Service\CachedKeyChainGenerator;
 use oat\taoLti\models\classes\Platform\Service\KeyChainGeneratorInterface;
 
 final class Version202008131228163772_taoLti extends AbstractMigration
@@ -31,6 +31,6 @@ final class Version202008131228163772_taoLti extends AbstractMigration
      */
     private function getKeyChainGenerator(): KeyChainGeneratorInterface
     {
-        return $this->getServiceLocator()->get(KeyChainGenerator::class);
+        return $this->getServiceLocator()->get(CachedKeyChainGenerator::class);
     }
 }

--- a/migrations/Version202008131228163772_taoLti.php
+++ b/migrations/Version202008131228163772_taoLti.php
@@ -11,7 +11,6 @@ use oat\taoLti\models\classes\Platform\Service\KeyChainGeneratorInterface;
 
 final class Version202008131228163772_taoLti extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Will generate keyChain and store in persistence';

--- a/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php
@@ -14,7 +14,7 @@ use oat\tao\model\security\Business\Contract\KeyChainRepositoryInterface;
 use oat\tao\model\security\Business\Domain\Key\KeyChain as TaoKeyChain;
 use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
-use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\ToolKeyChainRepository;
 
 class Lti1p3RegistrationRepository extends ConfigurableService implements RegistrationRepositoryInterface
@@ -25,11 +25,11 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
     public function find(string $identifier): ?RegistrationInterface
     {
         $toolKeyChain = $this->getToolKeyChainRepository()
-                ->findAll(new KeyChainQuery())
+                ->findAll(new KeyChainQuery($identifier))
                 ->getKeyChains()[0] ?? null;
 
         $platformKeyChain = $this->getPlatformKeyChainRepository()
-                ->findAll(new KeyChainQuery())
+                ->findAll(new KeyChainQuery($identifier))
                 ->getKeyChains()[0] ?? null;
 
         if ($toolKeyChain === null || $platformKeyChain === null) {
@@ -82,7 +82,7 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
 
     private function getPlatformKeyChainRepository(): KeyChainRepositoryInterface
     {
-        return $this->getServiceLocator()->get(PlatformKeyChainRepository::SERVICE_ID);
+        return $this->getServiceLocator()->get(CachedPlatformKeyChainRepository::class);
     }
 
     private function translateKeyChain(TaoKeyChain $keyChain): KeyChain

--- a/models/classes/Platform/Service/CachedKeyChainGenerator.php
+++ b/models/classes/Platform/Service/CachedKeyChainGenerator.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Service;
+
+use oat\oatbox\cache\SimpleCache;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\security\Business\Contract\KeyChainRepositoryInterface;
+use oat\tao\model\security\Business\Domain\Key\KeyChain;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformJwksRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use Psr\SimpleCache\CacheInterface;
+
+class CachedKeyChainGenerator extends ConfigurableService implements KeyChainGeneratorInterface
+{
+    public function generate(): KeyChain
+    {
+        $keyChain = $this->getKeyChainGenerator()->generate();
+        $this->getKeyChainRepository()->save($keyChain);
+
+        $this->invalidateKeyChain($keyChain);
+        $this->invalidateJwks();
+
+        return $keyChain;
+    }
+
+    private function invalidateKeyChain(KeyChain $keyChain): void
+    {
+        $this->getCache()->delete(
+            sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, $keyChain->getIdentifier())
+        );
+
+        $this->getCache()->delete(
+            sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, $keyChain->getIdentifier())
+        );
+    }
+
+    private function invalidateJwks(): void
+    {
+        $this->getCache()->delete(CachedPlatformJwksRepository::JWKS_KEY);
+    }
+
+    private function getKeyChainGenerator(): KeyChainGeneratorInterface
+    {
+        return $this->getServiceLocator()->get(KeyChainGenerator::class);
+    }
+
+    private function getKeyChainRepository(): KeyChainRepositoryInterface
+    {
+        return $this->getServiceLocator()->get(PlatformKeyChainRepository::class);
+    }
+
+    private function getCache(): CacheInterface
+    {
+        return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
+    }
+
+}

--- a/models/classes/Platform/Service/KeyChainGenerator.php
+++ b/models/classes/Platform/Service/KeyChainGenerator.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Service;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\security\Business\Domain\Key\Key;
+use oat\tao\model\security\Business\Domain\Key\KeyChain;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+
+class KeyChainGenerator extends ConfigurableService
+{
+    private const SSL_CONFIG = [
+        'digest_alg' => 'sha256',
+        'private_key_bits' => 4096,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ];
+
+    public function getKeyChain(): KeyChain
+    {
+        $resource = openssl_pkey_new(self::SSL_CONFIG);
+        openssl_pkey_export($resource, $privateKey);
+        $publicKey = openssl_pkey_get_details($resource);
+
+        $keyChain = new KeyChain(
+            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID,
+            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME,
+            new Key($publicKey['key']),
+            new Key($privateKey)
+        );
+
+        return $keyChain;
+    }
+}

--- a/models/classes/Platform/Service/KeyChainGenerator.php
+++ b/models/classes/Platform/Service/KeyChainGenerator.php
@@ -29,15 +29,9 @@ use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRep
 
 class KeyChainGenerator extends ConfigurableService implements KeyChainGeneratorInterface
 {
-    private const SSL_CONFIG = [
-        'digest_alg' => 'sha256',
-        'private_key_bits' => 4096,
-        'private_key_type' => OPENSSL_KEYTYPE_RSA,
-    ];
-
     public function generate(): KeyChain
     {
-        $resource = openssl_pkey_new(self::SSL_CONFIG);
+        $resource = openssl_pkey_new($this->getOption(self::OPTION_DATA_STORE));
         openssl_pkey_export($resource, $privateKey);
         $publicKey = openssl_pkey_get_details($resource);
 

--- a/models/classes/Platform/Service/KeyChainGeneratorInterface.php
+++ b/models/classes/Platform/Service/KeyChainGeneratorInterface.php
@@ -22,30 +22,9 @@ declare(strict_types=1);
 
 namespace oat\taoLti\models\classes\Platform\Service;
 
-use oat\oatbox\service\ConfigurableService;
-use oat\tao\model\security\Business\Domain\Key\Key;
 use oat\tao\model\security\Business\Domain\Key\KeyChain;
-use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 
-class KeyChainGenerator extends ConfigurableService implements KeyChainGeneratorInterface
+interface KeyChainGeneratorInterface
 {
-    private const SSL_CONFIG = [
-        'digest_alg' => 'sha256',
-        'private_key_bits' => 4096,
-        'private_key_type' => OPENSSL_KEYTYPE_RSA,
-    ];
-
-    public function generate(): KeyChain
-    {
-        $resource = openssl_pkey_new(self::SSL_CONFIG);
-        openssl_pkey_export($resource, $privateKey);
-        $publicKey = openssl_pkey_get_details($resource);
-
-        return new KeyChain(
-            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID,
-            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME,
-            new Key($publicKey['key']),
-            new Key($privateKey)
-        );
-    }
+    public function generate(): KeyChain;
 }

--- a/models/classes/Security/DataAccess/Repository/CacheKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CacheKeyChainRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Security\DataAccess\Repository;
+
+use oat\oatbox\cache\SimpleCache;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\security\Business\Contract\KeyChainRepositoryInterface;
+use oat\tao\model\security\Business\Domain\Key\Key;
+use oat\tao\model\security\Business\Domain\Key\KeyChain;
+use oat\tao\model\security\Business\Domain\Key\KeyChainCollection;
+use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
+use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
+use Psr\SimpleCache\InvalidArgumentException;
+
+class CacheKeyChainRepository extends ConfigurableService implements KeyChainRepositoryInterface
+{
+    public const PRIVATE_PREFIX = 'PLATFORM_LTI_PRIVATE_KEY';
+    public const PUBLIC_PREFIX = 'PLATFORM_LTI_PUBLIC_KEY_';
+    private const OPTION_DEFAULT_KEY_NAME = 'defaultKeyName';
+
+    public function save(KeyChain $keyChain): void
+    {
+        $this->saveKeys($keyChain);
+    }
+
+    public function findAll(KeyChainQuery $query): KeyChainCollection
+    {
+        if (!(
+            $this->getCacheService()->has(self::PRIVATE_PREFIX . $query->getIdentifier()) ||
+            $this->getCacheService()->has(self::PUBLIC_PREFIX . $query->getIdentifier())
+        )) {
+            $this->saveKeys($this->getKeyChainGenerator()->getKeyChain());
+        }
+
+        $keyChain = new KeyChain(
+            $query->getIdentifier(),
+            self::OPTION_DEFAULT_KEY_NAME,
+            new Key($this->getCacheService()->get(self::PUBLIC_PREFIX . $query->getIdentifier())),
+            new Key($this->getCacheService()->get(self::PRIVATE_PREFIX . $query->getIdentifier()))
+        );
+
+        return new KeyChainCollection($keyChain);
+    }
+
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function saveKeys(KeyChain $keyChain): void
+    {
+        $this->getCacheService()->set(self::PRIVATE_PREFIX . $keyChain->getIdentifier(), $keyChain->getPrivateKey());
+        $this->getCacheService()->set(self::PUBLIC_PREFIX . $keyChain->getIdentifier(), $keyChain->getPublicKey());
+    }
+
+    private function getCacheService(): SimpleCache
+    {
+        return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
+    }
+
+    private function getKeyChainGenerator(): KeyChainGenerator
+    {
+        return $this->getServiceLocator()->get(KeyChainGenerator::class);
+    }
+}

--- a/models/classes/Security/DataAccess/Repository/CacheKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CacheKeyChainRepository.php
@@ -41,6 +41,7 @@ class CacheKeyChainRepository extends ConfigurableService implements KeyChainRep
     public function save(KeyChain $keyChain): void
     {
         $this->saveKeys($keyChain);
+        $this->getPlatformKeyChainRepository()->save($keyChain);
     }
 
     public function findAll(KeyChainQuery $query): KeyChainCollection
@@ -80,5 +81,10 @@ class CacheKeyChainRepository extends ConfigurableService implements KeyChainRep
     private function getKeyChainGenerator(): KeyChainGenerator
     {
         return $this->getServiceLocator()->get(KeyChainGenerator::class);
+    }
+
+    private function getPlatformKeyChainRepository(): KeyChainRepositoryInterface
+    {
+        return $this->getServiceLocator()->get(PlatformKeyChainRepository::SERVICE_ID);
     }
 }

--- a/models/classes/Security/DataAccess/Repository/CacheKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CacheKeyChainRepository.php
@@ -63,7 +63,6 @@ class CacheKeyChainRepository extends ConfigurableService implements KeyChainRep
         return new KeyChainCollection($keyChain);
     }
 
-
     /**
      * @throws InvalidArgumentException
      */

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
@@ -26,6 +26,7 @@ use oat\oatbox\cache\SimpleCache;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\security\Business\Contract\JwksRepositoryInterface;
 use oat\tao\model\security\Business\Domain\Key\Jwks;
+use Psr\SimpleCache\CacheInterface;
 
 class CachedPlatformJwksRepository extends ConfigurableService implements JwksRepositoryInterface
 {
@@ -40,6 +41,7 @@ class CachedPlatformJwksRepository extends ConfigurableService implements JwksRe
         }
 
         $jwks = $this->getJwksRepository()->find();
+
         $this->getCacheService()->set(self::JWKS_KEY, $jwks->jsonSerialize());
 
         return $jwks;
@@ -50,7 +52,7 @@ class CachedPlatformJwksRepository extends ConfigurableService implements JwksRe
         return $this->getServiceLocator()->get(PlatformJwksRepository::class);
     }
 
-    private function getCacheService(): SimpleCache
+    private function getCacheService(): CacheInterface
     {
         return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
     }

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace oat\taoLti\models\classes\Security\DataAccess\Repository;
 
-use oat\oatbox\cache\MultipleCacheTrait;
 use oat\oatbox\cache\SimpleCache;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\security\Business\Contract\JwksRepositoryInterface;

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Security\DataAccess\Repository;
+
+use oat\oatbox\cache\MultipleCacheTrait;
+use oat\oatbox\cache\SimpleCache;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\security\Business\Contract\JwksRepositoryInterface;
+use oat\tao\model\security\Business\Domain\Key\Jwks;
+
+class CachedPlatformJwksRepository extends ConfigurableService implements JwksRepositoryInterface
+{
+    use MultipleCacheTrait;
+
+    private const JWKS_KEY = 'PLATFORM_JWKS';
+
+    public function find(): Jwks
+    {
+        $jwks = $this->getJwksRepository()->find();
+        $this->invalidateCache($jwks);
+
+        return $jwks;
+    }
+
+    private function invalidateCache(Jwks $jwks): void
+    {
+        if ($this->getCacheService()->has(self::JWKS_KEY)) {
+            $this->getCacheService()->delete(self::JWKS_KEY);
+        }
+        $this->getCacheService()->set(self::JWKS_KEY, $jwks->jsonSerialize());
+    }
+
+    private function getJwksRepository(): JwksRepositoryInterface
+    {
+        return $this->getServiceLocator()->get(PlatformJwksRepository::class);
+    }
+
+    private function getCacheService(): SimpleCache
+    {
+        return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
+    }
+}

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
@@ -30,8 +30,6 @@ use oat\tao\model\security\Business\Domain\Key\Jwks;
 
 class CachedPlatformJwksRepository extends ConfigurableService implements JwksRepositoryInterface
 {
-    use MultipleCacheTrait;
-
     public const JWKS_KEY = 'PLATFORM_JWKS';
 
     public function find(): Jwks

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepository.php
@@ -32,22 +32,20 @@ class CachedPlatformJwksRepository extends ConfigurableService implements JwksRe
 {
     use MultipleCacheTrait;
 
-    private const JWKS_KEY = 'PLATFORM_JWKS';
+    public const JWKS_KEY = 'PLATFORM_JWKS';
 
     public function find(): Jwks
     {
+        if ($this->getCacheService()->has(self::JWKS_KEY)) {
+            $jwks = $this->getCacheService()->get(self::JWKS_KEY);
+
+            return new Jwks(...$jwks['keys']);
+        }
+
         $jwks = $this->getJwksRepository()->find();
-        $this->invalidateCache($jwks);
+        $this->getCacheService()->set(self::JWKS_KEY, $jwks->jsonSerialize());
 
         return $jwks;
-    }
-
-    private function invalidateCache(Jwks $jwks): void
-    {
-        if ($this->getCacheService()->has(self::JWKS_KEY)) {
-            $this->getCacheService()->delete(self::JWKS_KEY);
-        }
-        $this->getCacheService()->set(self::JWKS_KEY, $jwks->jsonSerialize());
     }
 
     private function getJwksRepository(): JwksRepositoryInterface

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
@@ -86,12 +86,18 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
     private function setKeys(KeyChain $keyChain, KeyChainQuery $query): void
     {
         $this->getCacheService()->set(
-            sprintf(self::PRIVATE_PATTERN, $query->getIdentifier()),
+            sprintf(self::PRIVATE_PATTERN,
+                $query->getIdentifier()
+            ),
+
             $keyChain->getPrivateKey()->getValue()
         );
 
         $this->getCacheService()->set(
-            sprintf(self::PUBLIC_PATTERN, $query->getIdentifier()),
+            sprintf(self::PUBLIC_PATTERN,
+                $query->getIdentifier()
+            ),
+
             $keyChain->getPublicKey()->getValue()
         );
     }

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
@@ -40,7 +40,7 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
 
     public function save(KeyChain $keyChain): void
     {
-        $this->saveKeys($keyChain);
+        $this->setKeys($keyChain);
         $this->getPlatformKeyChainRepository()->save($keyChain);
     }
 
@@ -50,7 +50,7 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
             $this->getCacheService()->has(self::PRIVATE_PREFIX . $query->getIdentifier()) ||
             $this->getCacheService()->has(self::PUBLIC_PREFIX . $query->getIdentifier())
         )) {
-            $this->saveKeys($this->getKeyChainGenerator()->getKeyChain());
+            $this->setKeys($this->getKeyChainGenerator()->getKeyChain());
         }
 
         $keyChain = new KeyChain(
@@ -66,7 +66,7 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
     /**
      * @throws InvalidArgumentException
      */
-    private function saveKeys(KeyChain $keyChain): void
+    private function setKeys(KeyChain $keyChain): void
     {
         $this->getCacheService()->set(self::PRIVATE_PREFIX . $keyChain->getIdentifier(), $keyChain->getPrivateKey());
         $this->getCacheService()->set(self::PUBLIC_PREFIX . $keyChain->getIdentifier(), $keyChain->getPublicKey());

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
@@ -29,6 +29,7 @@ use oat\tao\model\security\Business\Domain\Key\Key;
 use oat\tao\model\security\Business\Domain\Key\KeyChain;
 use oat\tao\model\security\Business\Domain\Key\KeyChainCollection;
 use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
+use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 
 class CachedPlatformKeyChainRepository extends ConfigurableService implements KeyChainRepositoryInterface
@@ -95,7 +96,7 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
             $this->getCacheService()->has(sprintf(self::PUBLIC_PATTERN, $query->getIdentifier()));
     }
 
-    private function getCacheService(): SimpleCache
+    private function getCacheService(): CacheInterface
     {
         return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
     }

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
@@ -32,9 +32,9 @@ use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
 use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
 use Psr\SimpleCache\InvalidArgumentException;
 
-class CacheKeyChainRepository extends ConfigurableService implements KeyChainRepositoryInterface
+class CachedPlatformKeyChainRepository extends ConfigurableService implements KeyChainRepositoryInterface
 {
-    public const PRIVATE_PREFIX = 'PLATFORM_LTI_PRIVATE_KEY';
+    public const PRIVATE_PREFIX = 'PLATFORM_LTI_PRIVATE_KEY_';
     public const PUBLIC_PREFIX = 'PLATFORM_LTI_PUBLIC_KEY_';
     private const OPTION_DEFAULT_KEY_NAME = 'defaultKeyName';
 

--- a/scripts/install/GenerateKeys.php
+++ b/scripts/install/GenerateKeys.php
@@ -20,13 +20,15 @@
 
 declare(strict_types=1);
 
-namespace oat\taoLti\models\classes\Platform\Service;
+namespace oat\taoLti\scripts\install;
 
-use oat\tao\model\security\Business\Domain\Key\KeyChain;
+use oat\oatbox\extension\AbstractAction;
+use oat\taoLti\models\classes\Platform\Service\CachedKeyChainGenerator;
 
-interface KeyChainGeneratorInterface
+class GenerateKeys extends AbstractAction
 {
-    public const OPTION_DATA_STORE = 'sslConfig';
-
-    public function generate(): KeyChain;
+    public function __invoke($params)
+    {
+        $this->getServiceLocator()->get(CachedKeyChainGenerator::class)->generate();
+    }
 }

--- a/test/unit/models/classes/Platform/Repository/Lti1p3RegistrationRepositoryTest.php
+++ b/test/unit/models/classes/Platform/Repository/Lti1p3RegistrationRepositoryTest.php
@@ -29,7 +29,7 @@ use oat\tao\model\security\Business\Domain\Key\Key;
 use oat\tao\model\security\Business\Domain\Key\KeyChain;
 use oat\tao\model\security\Business\Domain\Key\KeyChainCollection;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
-use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\ToolKeyChainRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -65,13 +65,13 @@ class Lti1p3RegistrationRepositoryTest extends TestCase
             new Key('tool_private_key')
         );
         $this->toolKeyChainRepository = $this->createMock(KeyChainRepositoryInterface::class);
-        $this->platformKeyChainRepository = $this->createMock(KeyChainRepositoryInterface::class);
+        $this->platformKeyChainRepository = $this->createMock(CachedPlatformKeyChainRepository::class);
         $this->subject = new Lti1p3RegistrationRepository();
         $this->subject->setServiceLocator(
             $this->getServiceLocatorMock(
                 [
                     ToolKeyChainRepository::class => $this->toolKeyChainRepository,
-                    PlatformKeyChainRepository::SERVICE_ID => $this->platformKeyChainRepository,
+                    CachedPlatformKeyChainRepository::class => $this->platformKeyChainRepository
                 ]
             )
         );

--- a/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
@@ -45,13 +45,15 @@ class CachedKeyChainGeneratorTest extends TestCase
             new Key('private key')
         );
 
-        $this->subject->setServiceLocator($this->getServiceLocatorMock(
-            [
-                KeyChainGenerator::class => $this->keyChainGeneratorMock,
-                PlatformKeyChainRepository::class => $this->platformKeyChainRepositoryMock,
-                SimpleCache::SERVICE_ID => $this->simpleCacheMock,
-            ]
-        ));
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    KeyChainGenerator::class => $this->keyChainGeneratorMock,
+                    PlatformKeyChainRepository::class => $this->platformKeyChainRepositoryMock,
+                    SimpleCache::SERVICE_ID => $this->simpleCacheMock,
+                ]
+            )
+        );
     }
 
     public function testGenerate(): void

--- a/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace oat\taoLti\test\unit\models\classes\Platform\Service;
+
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\cache\SimpleCache;
+use oat\tao\model\security\Business\Domain\Key\Key;
+use oat\tao\model\security\Business\Domain\Key\KeyChain;
+use oat\taoLti\models\classes\Platform\Service\CachedKeyChainGenerator;
+use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformJwksRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+
+class CachedKeyChainGeneratorTest extends TestCase
+{
+    /** @var CachedKeyChainGenerator */
+    private $subject;
+
+    /** @var KeyChainGenerator|MockObject */
+    private $keyChainGeneratorMock;
+
+    /** @var PlatformKeyChainRepository|MockObject */
+    private $platformKeyChainRepositoryMock;
+
+    /** @var SimpleCache|MockObject */
+    private $simpleCacheMock;
+
+    /** @var KeyChain */
+    private $keyChain;
+
+    public function setUp(): void
+    {
+
+        $this->subject = new CachedKeyChainGenerator();
+        $this->keyChainGeneratorMock = $this->createMock(KeyChainGenerator::class);
+        $this->platformKeyChainRepositoryMock = $this->createMock(PlatformKeyChainRepository::class);
+        $this->simpleCacheMock = $this->createMock(SimpleCache::class);
+
+        $this->keyChain = new KeyChain(
+            'id',
+            'name',
+            new Key('public key'),
+            new Key('private key')
+        );
+
+        $this->subject->setServiceLocator($this->getServiceLocatorMock(
+            [
+                KeyChainGenerator::class => $this->keyChainGeneratorMock,
+                PlatformKeyChainRepository::class => $this->platformKeyChainRepositoryMock,
+                SimpleCache::SERVICE_ID => $this->simpleCacheMock,
+            ]
+        ));
+    }
+
+    public function testGenerate(): void
+    {
+        $this->keyChainGeneratorMock
+            ->expects($this->once())
+            ->method('generate')
+            ->willReturn($this->keyChain);
+
+        $this->platformKeyChainRepositoryMock
+            ->expects($this->once())
+            ->method('save');
+
+        $this->simpleCacheMock
+            ->expects($this->exactly(3))
+            ->method('delete')
+            ->withConsecutive(
+                [sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, 'id')],
+                [sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, 'id')],
+                [CachedPlatformJwksRepository::JWKS_KEY]
+            );
+
+        $this->subject->generate();
+    }
+}

--- a/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
@@ -37,7 +37,7 @@ class KeyChainGeneratorTest extends TestCase
 
     public function testGetPublicKey(): void
     {
-        $result = $this->subject->getKeyChain();
+        $result = $this->subject->generate();
 
         $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getValue());
         $this->assertStringContainsString('-----END PRIVATE KEY-----', $result->getPrivateKey()->getValue());

--- a/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\test\unit\models\classes\Platform\Service;
+
+use oat\generis\test\TestCase;
+use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
+
+class KeyChainGeneratorTest extends TestCase
+{
+    /** @var KeyChainGenerator */
+    private $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new KeyChainGenerator();
+    }
+
+    public function testGetPublicKey(): void
+    {
+        $result = $this->subject->getKeyChain();
+
+        $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getValue());
+        $this->assertStringContainsString('-----END PRIVATE KEY-----', $result->getPrivateKey()->getValue());
+        $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getValue());
+        $this->assertStringContainsString('-----END PUBLIC KEY-----', $result->getPublicKey()->getValue());
+    }
+}

--- a/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
@@ -35,7 +35,7 @@ class KeyChainGeneratorTest extends TestCase
         $this->subject = new KeyChainGenerator();
     }
 
-    public function testGetPublicKey(): void
+    public function testGenerate(): void
     {
         $result = $this->subject->generate();
 

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -37,6 +37,7 @@ use oat\tao\model\security\Business\Domain\Key\KeyChain;
 use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
 use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\CacheKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 
 class CacheKeyChainRepositoryTest extends TestCase
 {
@@ -50,16 +51,21 @@ class CacheKeyChainRepositoryTest extends TestCase
     /** @var KeyChainGenerator|MockObject */
     private $keyChainGeneratorMock;
 
+    /** @var PlatformKeyChainRepository|MockObject */
+    private $platformKeyChainRepositoryMock;
+
     public function setUp(): void
     {
         $this->subject = new CacheKeyChainRepository();
         $this->simpleCacheMock = $this->createMock(SimpleCache::class);
         $this->keyChainGeneratorMock = $this->createMock(KeyChainGenerator::class);
+        $this->platformKeyChainRepositoryMock = $this->createMock(PlatformKeyChainRepository::class);
 
         $this->subject->setServiceLocator($this->getServiceLocatorMock(
             [
                 SimpleCache::SERVICE_ID => $this->simpleCacheMock,
                 KeyChainGenerator::class => $this->keyChainGeneratorMock,
+                PlatformKeyChainRepository::SERVICE_ID => $this->platformKeyChainRepositoryMock
             ]
         ));
     }
@@ -75,6 +81,10 @@ class CacheKeyChainRepositoryTest extends TestCase
                 [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
                 [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
             );
+
+        $this->platformKeyChainRepositoryMock
+            ->expects($this->once())
+            ->method('save');
 
         $this->subject->save($keyChain);
     }

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -35,6 +35,7 @@ use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRep
 class CacheKeyChainRepositoryTest extends TestCase
 {
     public const IDENTIFIER = 'id';
+
     /** @var CachedPlatformKeyChainRepository */
     private $subject;
 
@@ -143,6 +144,7 @@ class CacheKeyChainRepositoryTest extends TestCase
         $result = $this->subject->findAll($keyChainQuery);
 
         $keyChainCollection = $result->getKeyChains();
+
         $this->assertSame(self::IDENTIFIER, $keyChainCollection[0]->getIdentifier());
         $this->assertSame('privateKey', $keyChainCollection[0]->getPrivateKey()->getValue());
         $this->assertSame('publicKey', $keyChainCollection[0]->getPublicKey()->getValue());

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -36,13 +36,13 @@ use oat\tao\model\security\Business\Domain\Key\Key;
 use oat\tao\model\security\Business\Domain\Key\KeyChain;
 use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
 use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
-use oat\taoLti\models\classes\Security\DataAccess\Repository\CacheKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 
 class CacheKeyChainRepositoryTest extends TestCase
 {
     public const IDENTIFIER = 'id';
-    /** @var CacheKeyChainRepository */
+    /** @var CachedPlatformKeyChainRepository */
     private $subject;
 
     /** @var SimpleCache|MockObject */
@@ -56,7 +56,7 @@ class CacheKeyChainRepositoryTest extends TestCase
 
     public function setUp(): void
     {
-        $this->subject = new CacheKeyChainRepository();
+        $this->subject = new CachedPlatformKeyChainRepository();
         $this->simpleCacheMock = $this->createMock(SimpleCache::class);
         $this->keyChainGeneratorMock = $this->createMock(KeyChainGenerator::class);
         $this->platformKeyChainRepositoryMock = $this->createMock(PlatformKeyChainRepository::class);
@@ -78,8 +78,8 @@ class CacheKeyChainRepositoryTest extends TestCase
             ->expects($this->exactly(2))
             ->method('set')
             ->withConsecutive(
-                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
-                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
+                [CachedPlatformKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
+                [CachedPlatformKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
             );
 
         $this->platformKeyChainRepositoryMock
@@ -98,8 +98,8 @@ class CacheKeyChainRepositoryTest extends TestCase
         $this->simpleCacheMock
             ->method('has')
             ->withConsecutive(
-                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER],
-                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER]
+                [CachedPlatformKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER],
+                [CachedPlatformKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER]
             )
             ->willReturnOnConsecutiveCalls(
                 false,
@@ -115,8 +115,8 @@ class CacheKeyChainRepositoryTest extends TestCase
             ->expects($this->exactly(2))
             ->method('set')
             ->withConsecutive(
-                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
-                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
+                [CachedPlatformKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
+                [CachedPlatformKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
             );
 
 
@@ -124,8 +124,8 @@ class CacheKeyChainRepositoryTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->withConsecutive(
-                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER],
-                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER]
+                [CachedPlatformKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER],
+                [CachedPlatformKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER]
             )->willReturnOnConsecutiveCalls(
                 'publicKey',
                 'privateKey'
@@ -141,8 +141,8 @@ class CacheKeyChainRepositoryTest extends TestCase
         $this->simpleCacheMock
             ->method('has')
             ->withConsecutive(
-                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER],
-                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER]
+                [CachedPlatformKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER],
+                [CachedPlatformKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER]
             )
             ->willReturnOnConsecutiveCalls(
                 true,
@@ -153,8 +153,8 @@ class CacheKeyChainRepositoryTest extends TestCase
             ->expects($this->exactly(2))
             ->method('get')
             ->withConsecutive(
-                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER],
-                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER]
+                [CachedPlatformKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER],
+                [CachedPlatformKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER]
             )->willReturnOnConsecutiveCalls(
                 'publicKey',
                 'privateKey'

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -51,12 +51,14 @@ class CacheKeyChainRepositoryTest extends TestCase
         $this->simpleCacheMock = $this->createMock(SimpleCache::class);
         $this->platformKeyChainRepositoryMock = $this->createMock(PlatformKeyChainRepository::class);
 
-        $this->subject->setServiceLocator($this->getServiceLocatorMock(
-            [
-                SimpleCache::SERVICE_ID => $this->simpleCacheMock,
-                PlatformKeyChainRepository::SERVICE_ID => $this->platformKeyChainRepositoryMock,
-            ]
-        ));
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    SimpleCache::SERVICE_ID => $this->simpleCacheMock,
+                    PlatformKeyChainRepository::SERVICE_ID => $this->platformKeyChainRepositoryMock,
+                ]
+            )
+        );
     }
 
     public function testSave(): void

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -20,13 +20,6 @@
 
 declare(strict_types=1);
 
-/**
- * Created by PhpStorm.
- * User: bartlomiejmarszal
- * Date: 2020-08-11
- * Time: 13:50
- */
-
 namespace oat\taoLti\test\unit\models\classes\Security\DataAccess\Repository;
 
 use oat\generis\test\MockObject;

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -160,13 +160,11 @@ class CacheKeyChainRepositoryTest extends TestCase
         $publicKey = new Key('publicKey');
         $privateKey = new Key('privateKey');
 
-        $keyChain = new KeyChain(
+        return new KeyChain(
             self::IDENTIFIER,
             'name',
             $publicKey,
             $privateKey
         );
-
-        return $keyChain;
     }
 }

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+/**
+ * Created by PhpStorm.
+ * User: bartlomiejmarszal
+ * Date: 2020-08-11
+ * Time: 13:50
+ */
+
+namespace oat\taoLti\test\unit\models\classes\Security\DataAccess\Repository;
+
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\cache\SimpleCache;
+use oat\tao\model\security\Business\Domain\Key\Key;
+use oat\tao\model\security\Business\Domain\Key\KeyChain;
+use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
+use oat\taoLti\models\classes\Platform\Service\KeyChainGenerator;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CacheKeyChainRepository;
+
+class CacheKeyChainRepositoryTest extends TestCase
+{
+    public const IDENTIFIER = 'id';
+    /** @var CacheKeyChainRepository */
+    private $subject;
+
+    /** @var SimpleCache|MockObject */
+    private $simpleCacheMock;
+
+    /** @var KeyChainGenerator|MockObject */
+    private $keyChainGeneratorMock;
+
+    public function setUp(): void
+    {
+        $this->subject = new CacheKeyChainRepository();
+        $this->simpleCacheMock = $this->createMock(SimpleCache::class);
+        $this->keyChainGeneratorMock = $this->createMock(KeyChainGenerator::class);
+
+        $this->subject->setServiceLocator($this->getServiceLocatorMock(
+            [
+                SimpleCache::SERVICE_ID => $this->simpleCacheMock,
+                KeyChainGenerator::class => $this->keyChainGeneratorMock,
+            ]
+        ));
+    }
+
+    public function testSave(): void
+    {
+        $keyChain = $this->getKeyChain();
+
+        $this->simpleCacheMock
+            ->expects($this->exactly(2))
+            ->method('set')
+            ->withConsecutive(
+                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
+                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
+            );
+
+        $this->subject->save($keyChain);
+    }
+
+
+    public function testFindAllWhenCacheEmpty(): void
+    {
+        $keyChain = $this->getKeyChain();
+        $keyChainQuery = new KeyChainQuery(self::IDENTIFIER);
+
+        $this->simpleCacheMock
+            ->method('has')
+            ->withConsecutive(
+                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER],
+                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER]
+            )
+            ->willReturnOnConsecutiveCalls(
+                false,
+                false
+            );
+
+        $this->keyChainGeneratorMock
+            ->expects($this->once())
+            ->method('getKeyChain')
+            ->willReturn($this->getKeyChain());
+
+        $this->simpleCacheMock
+            ->expects($this->exactly(2))
+            ->method('set')
+            ->withConsecutive(
+                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER, $keyChain->getPrivateKey()],
+                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER, $keyChain->getPublicKey()]
+            );
+
+
+        $this->simpleCacheMock
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->withConsecutive(
+                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER],
+                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER]
+            )->willReturnOnConsecutiveCalls(
+                'publicKey',
+                'privateKey'
+            );
+
+        $this->subject->findAll($keyChainQuery);
+    }
+
+    public function testFindAll(): void
+    {
+        $keyChainQuery = new KeyChainQuery(self::IDENTIFIER);
+
+        $this->simpleCacheMock
+            ->method('has')
+            ->withConsecutive(
+                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER],
+                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER]
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                true
+            );
+
+        $this->simpleCacheMock
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->withConsecutive(
+                [CacheKeyChainRepository::PUBLIC_PREFIX . self::IDENTIFIER],
+                [CacheKeyChainRepository::PRIVATE_PREFIX . self::IDENTIFIER]
+            )->willReturnOnConsecutiveCalls(
+                'publicKey',
+                'privateKey'
+            );
+
+        $result = $this->subject->findAll($keyChainQuery);
+
+        $keyChainCollection = $result->getKeyChains();
+        $this->assertSame(self::IDENTIFIER, $keyChainCollection[0]->getIdentifier());
+        $this->assertSame('privateKey', $keyChainCollection[0]->getPrivateKey()->getValue());
+        $this->assertSame('publicKey', $keyChainCollection[0]->getPublicKey()->getValue());
+    }
+
+    private function getKeyChain(): KeyChain
+    {
+        $publicKey = new Key('publicKey');
+        $privateKey = new Key('privateKey');
+
+        $keyChain = new KeyChain(
+            self::IDENTIFIER,
+            'name',
+            $publicKey,
+            $privateKey
+        );
+
+        return $keyChain;
+    }
+}

--- a/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CacheKeyChainRepositoryTest.php
@@ -69,8 +69,8 @@ class CacheKeyChainRepositoryTest extends TestCase
             ->expects($this->exactly(2))
             ->method('set')
             ->withConsecutive(
-                [sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, self::IDENTIFIER), $keyChain->getPrivateKey()],
-                [sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, self::IDENTIFIER), $keyChain->getPublicKey()]
+                [sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, self::IDENTIFIER), $keyChain->getPrivateKey()->getValue()],
+                [sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, self::IDENTIFIER), $keyChain->getPublicKey()->getValue()]
             );
 
         $this->platformKeyChainRepositoryMock
@@ -101,8 +101,8 @@ class CacheKeyChainRepositoryTest extends TestCase
             ->expects($this->exactly(2))
             ->method('set')
             ->withConsecutive(
-                [sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, self::IDENTIFIER), $keyChain->getPrivateKey()],
-                [sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, self::IDENTIFIER), $keyChain->getPublicKey()]
+                [sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, self::IDENTIFIER), $keyChain->getPrivateKey()->getValue()],
+                [sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, self::IDENTIFIER), $keyChain->getPublicKey()->getValue()]
             );
 
         $this->platformKeyChainRepositoryMock
@@ -138,8 +138,8 @@ class CacheKeyChainRepositoryTest extends TestCase
                 ]
             )->willReturn(
                 [
-                    'publicKey',
-                    'privateKey',
+                    sprintf(CachedPlatformKeyChainRepository::PRIVATE_PATTERN, self::IDENTIFIER) => 'privateKey',
+                    sprintf(CachedPlatformKeyChainRepository::PUBLIC_PATTERN, self::IDENTIFIER) => 'publicKey',
                 ]
             );
 

--- a/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepositoryTest.php
@@ -51,12 +51,14 @@ class CachedPlatformJwksRepositoryTest extends TestCase
         $this->platformJwksRepositoryMock = $this->createMock(PlatformJwksRepository::class);
         $this->cacheMock = $this->createMock(SimpleCache::class);
         $this->subject = new CachedPlatformJwksRepository();
-        $this->subject->setServiceLocator($this->getServiceLocatorMock(
-            [
-                PlatformJwksRepository::class => $this->platformJwksRepositoryMock,
-                SimpleCache::SERVICE_ID => $this->cacheMock,
-            ]
-        ));
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    PlatformJwksRepository::class => $this->platformJwksRepositoryMock,
+                    SimpleCache::SERVICE_ID => $this->cacheMock,
+                ]
+            )
+        );
 
         $this->jwk = new Jwk(
             'kty',

--- a/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepositoryTest.php
@@ -120,7 +120,8 @@ class CachedPlatformJwksRepositoryTest extends TestCase
             ->expects($this->once())
             ->method('set')
             ->with(
-                'PLATFORM_JWKS', $this->jwks->jsonSerialize()
+                'PLATFORM_JWKS',
+                $this->jwks->jsonSerialize()
             );
 
         $this->subject->find();

--- a/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformJwksRepositoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\test\unit\models\classes\Security\DataAccess\Repository;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\cache\SimpleCache;
+use oat\tao\model\security\Business\Domain\Key\Jwk;
+use oat\tao\model\security\Business\Domain\Key\Jwks;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformJwksRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformJwksRepository;
+
+class CachedPlatformJwksRepositoryTest extends TestCase
+{
+    /** @var CachedPlatformJwksRepository */
+    private $subject;
+
+    /** @var SimpleCache */
+    private $cacheMock;
+
+    /** @var PlatformJwksRepository */
+    private $platformJwksRepositoryMock;
+
+    /** @var Jwks  */
+    private $jwks;
+
+    public function setUp(): void
+    {
+        $this->platformJwksRepositoryMock = $this->createMock(PlatformJwksRepository::class);
+        $this->cacheMock = $this->createMock(SimpleCache::class);
+        $this->subject = new CachedPlatformJwksRepository();
+        $this->subject->setServiceLocator($this->getServiceLocatorMock(
+            [
+                PlatformJwksRepository::class => $this->platformJwksRepositoryMock,
+                SimpleCache::SERVICE_ID => $this->cacheMock,
+            ]
+        ));
+
+        $jwk = new Jwk(
+            'kty',
+            'e',
+            'n',
+            'kid',
+            'alg',
+            'use'
+        );
+
+        $this->jwks = new Jwks($jwk);
+
+    }
+
+    public function testCachedFind(): void
+    {
+        $this->platformJwksRepositoryMock
+            ->method('find')
+            ->willReturn($this->jwks);
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('has')
+            ->with('PLATFORM_JWKS')
+            ->willReturn(true);
+
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('delete')
+            ->with('PLATFORM_JWKS');
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                'PLATFORM_JWKS', $this->jwks->jsonSerialize()
+            );
+
+        $this->subject->find();
+    }
+
+    public function testNotCachedFind(): void
+    {
+
+        $this->platformJwksRepositoryMock
+            ->method('find')
+            ->willReturn($this->jwks);
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('has')
+            ->with('PLATFORM_JWKS')
+            ->willReturn(false);
+
+
+        $this->cacheMock
+            ->expects($this->never())
+            ->method('delete')
+            ->with('PLATFORM_JWKS');
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                'PLATFORM_JWKS', $this->jwks->jsonSerialize()
+            );
+
+        $this->subject->find();
+    }
+
+}


### PR DESCRIPTION
Created service responsible for the generation of JWK public and private keys. 
Including cache using KeyChainRepositoryInterface implementation

https://oat-sa.atlassian.net/browse/NEX-1534

To test this functionality you may use:
`https://{tao-url}/taoLti/Security/jwks`

Before you use is please install or update your instance in order to generate required `keyChains`. 