### PR TITLE
Fix validators names

### DIFF
--- a/models/classes/LtiProvider/Validation/ValidationRegistry.php
+++ b/models/classes/LtiProvider/Validation/ValidationRegistry.php
@@ -31,22 +31,22 @@ class ValidationRegistry extends ConfigurableService
 
     private const VALIDATORS = [
         '1.1' => [
-            DataStore::PROPERTY_OAUTH_KEY => [['notEmpty']],
-            DataStore::PROPERTY_OAUTH_SECRET => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_VERSION => [['notEmpty']],
+            DataStore::PROPERTY_OAUTH_KEY => [['NotEmpty']],
+            DataStore::PROPERTY_OAUTH_SECRET => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_VERSION => [['NotEmpty']],
         ],
         '1.3' => [
-            RdfLtiProviderRepository::LTI_VERSION => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_TOOL_CLIENT_ID => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_TOOL_IDENTIFIER => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_TOOL_NAME => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_TOOL_DEPLOYMENT_IDS => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_TOOL_AUDIENCE => [['notEmpty']],
-            RdfLtiProviderRepository::LTI_TOOL_OIDC_LOGIN_INITATION_URL => [['notEmpty'], ['url']],
-            RdfLtiProviderRepository::LTI_TOOL_LAUNCH_URL => [['url']],
+            RdfLtiProviderRepository::LTI_VERSION => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_TOOL_CLIENT_ID => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_TOOL_IDENTIFIER => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_TOOL_NAME => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_TOOL_DEPLOYMENT_IDS => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_TOOL_AUDIENCE => [['NotEmpty']],
+            RdfLtiProviderRepository::LTI_TOOL_OIDC_LOGIN_INITATION_URL => [['NotEmpty'], ['Url']],
+            RdfLtiProviderRepository::LTI_TOOL_LAUNCH_URL => [['Url']],
             RdfLtiProviderRepository::LTI_TOOL_JWKS_URL => [
                 [
-                    'url',
+                    'Url',
                     ['allow_empty' => true],
                 ],
                 [


### PR DESCRIPTION
This change fixes this error:

```Fatal error: Uncaught TypeError: Argument 1 passed to tao_helpers_form_FormElement::addValidator() must implement interface oat\oatbox\validator\ValidatorInterface, null given, called in /tao/code/tao/helpers/form/class.FormElement.php on line 398 and defined in /tao/code/tao/helpers/form/class.FormElement.php:380 Stack trace: #0 /tao/code/tao/helpers/form/class.FormElement.php(398): tao_helpers_form_FormElement->addValidator(NULL) #1 /tao/code/tao/helpers/form/class.FormContainer.php(202): tao_helpers_form_FormElement->addValidators(Array) #2 /tao/code/tao/helpers/form/class.FormContainer.php(101): tao_helpers_form_FormContainer->applyAdditionalValidationRules(Array) #3 /tao/code/tao/actions/form/class.CreateInstance.php(69): tao_helpers_form_FormContainer->__construct(Array, Array) #4 /tao/code/tao/actions/class.RdfController.php(550): tao_actions_form_CreateInstance->__construct(Array, Array) #5 [internal function]: tao_actions_RdfController->addInstanceForm() #6 /tao/code/tao/models/classes/routing/ActionEnforcer.php( in /tao/code/tao/helpers/form/class.FormElement.php on line 380```

