### PR TITLE
Sometimes ltiVersion in propertiesValues may not be a resource

### DIFF
--- a/models/classes/LtiProvider/LtiProviderFactory.php
+++ b/models/classes/LtiProvider/LtiProviderFactory.php
@@ -101,7 +101,7 @@ class LtiProviderFactory extends ConfigurableService
         $ltiVersionResource = reset($propertiesValues[RdfLtiProviderRepository::LTI_VERSION]);
 
         if ($ltiVersionResource instanceof core_kernel_classes_Literal && !empty(trim($ltiVersionResource->literal))) {
-            return $ltiVersionResource->literal;
+            return $ltiVersionResource->literal === RdfLtiProviderRepository::LTI_V_13 ? '1.3' : '1.1';
         }
 
         if (!$ltiVersionResource || !$ltiVersionResource instanceof core_kernel_classes_Resource) {

--- a/models/classes/LtiProvider/LtiProviderFactory.php
+++ b/models/classes/LtiProvider/LtiProviderFactory.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoLti\models\classes\LtiProvider;
 
+use core_kernel_classes_Literal;
 use core_kernel_classes_Resource;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\oauth\DataStore;
@@ -98,6 +99,10 @@ class LtiProviderFactory extends ConfigurableService
     private function getLtiVersion(array $propertiesValues): string
     {
         $ltiVersionResource = reset($propertiesValues[RdfLtiProviderRepository::LTI_VERSION]);
+
+        if ($ltiVersionResource instanceof core_kernel_classes_Literal && !empty(trim($ltiVersionResource->literal))) {
+            return $ltiVersionResource->literal;
+        }
 
         if (!$ltiVersionResource || !$ltiVersionResource instanceof core_kernel_classes_Resource) {
             return '1.1';

--- a/models/classes/LtiProvider/LtiProviderFactory.php
+++ b/models/classes/LtiProvider/LtiProviderFactory.php
@@ -97,11 +97,13 @@ class LtiProviderFactory extends ConfigurableService
 
     private function getLtiVersion(array $propertiesValues): string
     {
-        if (empty($propertiesValues[RdfLtiProviderRepository::LTI_VERSION])) {
+        $ltiVersionResource = reset($propertiesValues[RdfLtiProviderRepository::LTI_VERSION]);
+
+        if (!$ltiVersionResource || !$ltiVersionResource instanceof core_kernel_classes_Resource) {
             return '1.1';
         }
 
-        $version = (string)reset($propertiesValues[RdfLtiProviderRepository::LTI_VERSION])->getUri();
+        $version = (string) $ltiVersionResource->getUri();
 
         return $version === RdfLtiProviderRepository::LTI_V_13 ? '1.3' : '1.1';
     }


### PR DESCRIPTION
This errror may be encounter when searching for ltiProviders. 

`\oat\taoLti\models\classes\LtiProvider\LtiProviderFactory::getLtiVersion` 

We assume that propertiesValues[ltiVersion] will be a Resource but sometime is just Literal and getUri will throw an error. 