### PR TITLE
feat: LTI 1.3 Platforms & registration repo implemented

### DIFF
--- a/config/default/LtiPlatformRepository.conf.php
+++ b/config/default/LtiPlatformRepository.conf.php
@@ -1,0 +1,5 @@
+<?php
+
+use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
+
+return new RdfLtiPlatformRepository();

--- a/controller/PlatformAdmin.php
+++ b/controller/PlatformAdmin.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\taoLti\controller;
+
+use oat\oatbox\validator\ValidatorInterface;
+use oat\taoLti\models\classes\Platform\Validation\ValidatorsFactory;
+use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
+use tao_actions_SaSModule;
+
+/**
+ * This controller allows the additon and deletion
+ * of LTI 1.3 Platforms
+ *
+ * @package taoLti
+ * @license GPLv2 http://www.opensource.org/licenses/gpl-2.0.php
+ */
+class PlatformAdmin extends tao_actions_SaSModule
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getClassService()
+    {
+        return $this->getServiceLocator()->get(RdfLtiPlatformRepository::class);
+    }
+
+    /**
+     * @return ValidatorInterface[][]
+     */
+    protected function getExtraValidationRules(): array
+    {
+        return $this->getValidationFactory()->createFormValidators();
+    }
+
+    private function getValidationFactory(): ValidatorsFactory
+    {
+        return $this->getServiceLocator()->get(ValidatorsFactory::class);
+    }
+}

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -34,6 +34,30 @@
                     </action>
 				</actions>
 			</section>
+			<section id="settings_oauth_mng_platform" name="LTI 1.3 Platforms" url="/taoLti/PlatformAdmin/index">
+				<trees>
+					<tree name="LTI 1.3 Platforms"
+						  className="LTI 1.3 Platforms"
+						  dataUrl="/taoLti/PlatformAdmin/getOntologyData"
+						  rootNode="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"
+						  selectClass="ltiplatform-index"
+						  selectInstance="ltiplatform-edit"
+						  delete="ltiplatform-delete"
+					/>
+				</trees>
+				<actions>
+					<action id="ltiplatform-index" name="Index" url="/taoLti/PlatformAdmin/index" context="class" group="none" />
+					<action id="ltiplatform-edit" name="Properties" url="/taoLti/PlatformAdmin/editInstance" context="instance" group="none">
+						<icon id="icon-edit"/>
+					</action>
+					<action id="ltiplatform-delete" name="Delete" binding="removeNode" url="/taoLti/PlatformAdmin/delete" context="instance" group="tree">
+						<icon id="icon-bin"/>
+					</action>
+					<action id="ltiplatform-new" name="Add Platform" url="/taoLti/PlatformAdmin/addInstanceForm" context="class" group="tree">
+						<icon id="icon-add"/>
+					</action>
+				</actions>
+			</section>
 			<section id="settings_oauth_mng_provider" name="LTI Providers" url="/taoLti/ProviderAdmin/index">
 				<trees>
 					<tree name="LTI Providers"

--- a/install/ontology/lti.rdf
+++ b/install/ontology/lti.rdf
@@ -236,4 +236,71 @@
     <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextArea"/>
     <tao:TAOGUIOrder><![CDATA[1100]]></tao:TAOGUIOrder>
   </rdf:Description>
+
+    <!-- LTI 1.3 Platforms -->
+
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform">
+    <rdfs:label xml:lang="en-US"><![CDATA[LTI Platform]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[LTI Platform]]></rdfs:comment>
+    <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#TAOObject"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformClientId">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Client ID]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Client ID]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+    <tao:TAOGUIOrder><![CDATA[100]]></tao:TAOGUIOrder>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformDeploymentId">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Deployment ID]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Deployment ID]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+    <tao:TAOGUIOrder><![CDATA[200]]></tao:TAOGUIOrder>
+  </rdf:Description>
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformAudience">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Audience]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Audience]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"/>
+    <rdfs:range rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#TAOObject"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+    <tao:TAOGUIOrder><![CDATA[300]]></tao:TAOGUIOrder>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOuath2AccessTokenUrl">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Ouath2 Access Token URL]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Ouath2 Access Token URL]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+    <tao:TAOGUIOrder><![CDATA[400]]></tao:TAOGUIOrder>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOidcAuthenticationUrl">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[OIDC Authentication URL]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[OIDC Authentication URL]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"/>
+    <rdfs:range rdf:resource="http://www.tao.lu/middleware/wfEngine.rdf#ClassCallOfservicesResources"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+    <tao:TAOGUIOrder><![CDATA[500]]></tao:TAOGUIOrder>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformJwksUrl">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[JSON Web Key Sets URL]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[JSON Web Key Sets URL]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+    <tao:TAOGUIOrder><![CDATA[600]]></tao:TAOGUIOrder>
+  </rdf:Description>
 </rdf:RDF>

--- a/migrations/Version202108101321114915_taoLti.php
+++ b/migrations/Version202108101321114915_taoLti.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoLti\models\classes\Platform\Repository\LtiPlatformRepositoryInterface;
+use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202108101321114915_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update the Ontology model to install LTI 1.3 Platforms and register LTI Platform repository';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $this->getServiceManager()->register(
+            LtiPlatformRepositoryInterface::SERVICE_ID,
+            new RdfLtiPlatformRepository()
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration('Ontology should be re-synchronized after editing the source files.');
+    }
+}

--- a/models/classes/LtiProvider/ConfigurableLtiProviderRepository.php
+++ b/models/classes/LtiProvider/ConfigurableLtiProviderRepository.php
@@ -118,6 +118,19 @@ class ConfigurableLtiProviderRepository extends ConfigurableService implements L
         return null;
     }
 
+    public function searchByIssuer(string $issuer, ?string $clientId = null): ?LtiProvider
+    {
+        foreach ($this->getProviders() as $provider) {
+            if ($clientId !== null && $provider->getToolClientId() !== $clientId) {
+                continue;
+            }
+            if ($provider->getToolAudience() === $issuer) {
+                return $provider;
+            }
+        }
+        return null;
+    }
+
     private function getLtiProviderFactory(): LtiProviderFactory
     {
         /** @noinspection PhpIncompatibleReturnTypeInspection */

--- a/models/classes/LtiProvider/LtiProviderFieldsMapper.php
+++ b/models/classes/LtiProvider/LtiProviderFieldsMapper.php
@@ -46,6 +46,6 @@ class LtiProviderFieldsMapper extends ConfigurableService
 
     public function map(string $rdfUri): ?string
     {
-        return self::MAP [$rdfUri] ?? null;
+        return self::MAP[$rdfUri] ?? null;
     }
 }

--- a/models/classes/LtiProvider/LtiProviderService.php
+++ b/models/classes/LtiProvider/LtiProviderService.php
@@ -48,7 +48,7 @@ class LtiProviderService extends ConfigurableService implements LtiProviderRepos
         );
     }
 
-    public function searchByToolClientId(string $clientId): LtiProvider
+    public function searchByToolClientId(string $clientId): ?LtiProvider
     {
         foreach ($this->findAll() as $provider) {
             if ($clientId === $provider->getToolClientId()) {
@@ -56,7 +56,7 @@ class LtiProviderService extends ConfigurableService implements LtiProviderRepos
             }
         }
 
-        throw new InvalidLtiProviderException(sprintf('Lti provider with client id %s does not exist', $clientId));
+        return null;
     }
 
     /**

--- a/models/classes/LtiProvider/LtiProviderService.php
+++ b/models/classes/LtiProvider/LtiProviderService.php
@@ -133,4 +133,17 @@ class LtiProviderService extends ConfigurableService implements LtiProviderRepos
             ? reset($found)
             : null;
     }
+
+    public function searchByIssuer(string $issuer, ?string $clientId = null): ?LtiProvider
+    {
+        $found = array_filter($this->aggregate(
+            [],
+            static function ($providers, LtiProviderRepositoryInterface $implementation) use ($issuer, $clientId) {
+                return array_merge($providers, [$implementation->searchByIssuer($issuer, $clientId)]);
+            }
+        ));
+        return count($found) > 0
+            ? reset($found)
+            : null;
+    }
 }

--- a/models/classes/LtiProvider/RdfLtiProviderRepository.php
+++ b/models/classes/LtiProvider/RdfLtiProviderRepository.php
@@ -168,6 +168,24 @@ class RdfLtiProviderRepository extends OntologyClassService implements LtiProvid
         return reset($providers);
     }
 
+    public function searchByIssuer(string $issuer, string $clientId = null): ?LtiProvider
+    {
+        $criteria = [self::LTI_TOOL_AUDIENCE => $issuer];
+        if ($clientId !== null) {
+            $criteria[self::LTI_TOOL_CLIENT_ID] = $clientId;
+        }
+        $providers = $this->getProviders($criteria);
+        $count = count($providers);
+        if ($count === 0) {
+            return null;
+        }
+        if ($count > 1) {
+            $this->logWarning(sprintf('Found %d LTI provider with the same clientId: %s and audience: %s',
+                $count, $clientId, $issuer));
+        }
+        return reset($providers);
+    }
+
     private function getLtiProviderFactory(): LtiProviderFactory
     {
         return $this->getServiceLocator()->get(LtiProviderFactory::class);

--- a/models/classes/LtiProvider/Validation/ValidationRegistry.php
+++ b/models/classes/LtiProvider/Validation/ValidationRegistry.php
@@ -28,7 +28,6 @@ use oat\taoLti\models\classes\LtiProvider\RdfLtiProviderRepository;
 
 class ValidationRegistry extends ConfigurableService
 {
-
     private const VALIDATORS = [
         '1.1' => [
             DataStore::PROPERTY_OAUTH_KEY => [['NotEmpty']],

--- a/models/classes/Platform/LtiPlatform.php
+++ b/models/classes/Platform/LtiPlatform.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform;
+
+/**
+ * LTI platform Value Object.
+ */
+class LtiPlatform
+{
+    /** @var string */
+    private $id;
+
+    /** @var string */
+    private $label;
+
+    /** @var string */
+    private $clientId;
+
+    /** @var string */
+    private $deploymentId;
+
+    /** @var string */
+    private $audience;
+
+    /** @var string */
+    private $ouath2AccessTokenUrl;
+
+    /** @var string */
+    private $oidcAuthenticationUrl;
+
+    /** @var string */
+    private $jwksUrl;
+
+    public function __construct(
+        string $id,
+        string $label,
+        string $clientId,
+        string $deploymentId,
+        string $audience,
+        string $ouath2AccessTokenUrl,
+        string $oidcAuthenticationUrl,
+        string $jwksUrl
+    ) {
+        $this->id = $id;
+        $this->label = $label;
+        $this->clientId = $clientId;
+        $this->deploymentId = $deploymentId;
+        $this->audience = $audience;
+        $this->ouath2AccessTokenUrl = $ouath2AccessTokenUrl;
+        $this->oidcAuthenticationUrl = $oidcAuthenticationUrl;
+        $this->jwksUrl = $jwksUrl;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getClientId(): string
+    {
+        return $this->clientId;
+    }
+
+    public function getDeploymentId(): string
+    {
+        return $this->deploymentId;
+    }
+
+    public function getAudience(): string
+    {
+        return $this->audience;
+    }
+
+    public function getOuath2AccessTokenUrl(): string
+    {
+        return $this->ouath2AccessTokenUrl;
+    }
+
+    public function getOidcAuthenticationUrl(): string
+    {
+        return $this->oidcAuthenticationUrl;
+    }
+
+    public function getJwksUrl(): string
+    {
+        return $this->jwksUrl;
+    }
+}

--- a/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php
@@ -35,6 +35,7 @@ use oat\tao\model\security\Business\Domain\Key\KeyChain as TaoKeyChain;
 use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
+use oat\taoLti\models\classes\Platform\LtiPlatform;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\ToolKeyChainRepository;
 use OAT\Library\Lti1p3Core\Security\Key\Key;
@@ -44,6 +45,7 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
     public const SERVICE_ID = 'taoLti/Lti1p3RegistrationRepository';
     public const OPTION_ROOT_URL = 'rootUrl';
     private const PLATFORM_ID = 'tao';
+    private const TOOL_ID = 'tao_tool';
     private const OIDC_PATH = 'taoLti/Security/oidc';
     private const OAUTH_PATH = 'taoLti/Security/oauth';
     private const JWKS_PATH = 'taoLti/Security/jwks';
@@ -53,7 +55,12 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
         $ltiProvider = $this->getLtiProviderService()->searchById($identifier);
 
         if (!$ltiProvider) {
-            return null;
+            $ltiPlatform = $this->getLtiPlatformService()->searchById($identifier);
+            if ($ltiPlatform) {
+                return $this->createRegistrationByPlatform($ltiPlatform);
+            } else {
+                return null;
+            }
         }
 
         return $this->createRegistrationByProvider($ltiProvider);
@@ -61,29 +68,50 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
 
     public function findAll(): array
     {
-        $this->throwMissingImplementation(__METHOD__);
+        $registrations = [];
+
+        foreach ($this->getLtiProviderService()->findAll() as $ltiProvider) {
+            $registrations[] = $this->createRegistrationByProvider($ltiProvider);
+        }
+        foreach ($this->getLtiPlatformService()->findAll() as $ltiPlatform) {
+            $registrations[] = $this->createRegistrationByPlatform($ltiPlatform);
+        }
+
+        return $registrations;
     }
 
     public function findByClientId(string $clientId): ?RegistrationInterface
     {
         $ltiProvider = $this->getLtiProviderService()->searchByToolClientId($clientId);
 
+        if (!$ltiProvider) {
+            $ltiPlatform = $this->getLtiPlatformService()->searchByClientId($clientId);
+            if ($ltiPlatform) {
+                $this->createRegistrationByPlatform($ltiPlatform);
+            } else {
+                return null;
+            }
+        }
+
         return $this->createRegistrationByProvider($ltiProvider);
     }
 
     public function findByPlatformIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
     {
-        $this->throwMissingImplementation(__METHOD__);
+        $platform = $this->getLtiPlatformService()->searchByIssuer($issuer, $clientId);
+        if (!$platform) {
+            return null;
+        }
+        return $this->createRegistrationByPlatform($platform);
     }
 
     public function findByToolIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
     {
-        $this->throwMissingImplementation(__METHOD__);
-    }
-
-    private function throwMissingImplementation(string $method): void
-    {
-        throw new LogicException('Method ' . $method . ' was not required at needs to be implemented');
+        $provider = $this->getLtiProviderService()->searchByIssuer($issuer, $clientId);
+        if (!$provider) {
+            return null;
+        }
+        return $this->createRegistrationByProvider($provider);
     }
 
     private function getToolKeyChainRepository(): KeyChainRepositoryInterface
@@ -128,9 +156,14 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
         );
     }
 
-    private function getLtiProviderService(): LtiProviderService
+    private function getDefaultTool(): Tool
     {
-        return $this->getServiceLocator()->get(LtiProviderService::SERVICE_ID);
+        return new Tool(
+            self::TOOL_ID,
+            self::TOOL_ID,
+            rtrim($this->getOption(self::OPTION_ROOT_URL), '/'),
+            $this->getOption(self::OPTION_ROOT_URL) . self::OIDC_PATH
+        );
     }
 
     private function createRegistrationByProvider(LtiProvider $ltiProvider): ?Registration
@@ -163,5 +196,50 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
             $this->getOption(self::OPTION_ROOT_URL) . self::JWKS_PATH,
             $ltiProvider->getToolJwksUrl()
         );
+    }
+
+    private function createRegistrationByPlatform(LtiPlatform $ltiPlatform): ?Registration
+    {
+        $toolKeyChain = current($this->getToolKeyChainRepository()
+            ->findAll(new KeyChainQuery($ltiPlatform->getId()))
+            ->getKeyChains());
+
+        $platformKeyChain = current($this->getPlatformKeyChainRepository()
+            ->findAll(new KeyChainQuery($ltiPlatform->getId()))
+            ->getKeyChains());
+
+        if ($platformKeyChain === false) {
+            return null;
+        }
+
+        $translatedToolKeyChain = null;
+        if ($toolKeyChain !== false && empty($ltiPlatform->getJwksUrl())) {
+            $translatedToolKeyChain = $this->translateKeyChain($toolKeyChain);
+        }
+
+        $platform = new Platform($ltiPlatform->getId(), $ltiPlatform->getId(), $ltiPlatform->getAudience(),
+            $ltiPlatform->getOidcAuthenticationUrl(), $ltiPlatform->getOuath2AccessTokenUrl());
+
+        return new Registration(
+            $ltiPlatform->getId(),
+            $ltiPlatform->getClientId(),
+            $platform,
+            $this->getDefaultTool(),
+            [$ltiPlatform->getDeploymentId()],
+            $this->translateKeyChain($platformKeyChain),
+            $translatedToolKeyChain,
+            $ltiPlatform->getJwksUrl(),
+            $this->getOption(self::OPTION_ROOT_URL) . self::JWKS_PATH
+        );
+    }
+
+    private function getLtiProviderService(): LtiProviderService
+    {
+        return $this->getServiceLocator()->get(LtiProviderService::SERVICE_ID);
+    }
+
+    private function getLtiPlatformService(): LtiPlatformRepositoryInterface
+    {
+        return $this->getServiceLocator()->get(LtiPlatformRepositoryInterface::SERVICE_ID);
     }
 }

--- a/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php
@@ -87,7 +87,7 @@ class Lti1p3RegistrationRepository extends ConfigurableService implements Regist
         if (!$ltiProvider) {
             $ltiPlatform = $this->getLtiPlatformService()->searchByClientId($clientId);
             if ($ltiPlatform) {
-                $this->createRegistrationByPlatform($ltiPlatform);
+                return $this->createRegistrationByPlatform($ltiPlatform);
             } else {
                 return null;
             }

--- a/models/classes/Platform/Repository/LtiPlatformFactory.php
+++ b/models/classes/Platform/Repository/LtiPlatformFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\LtiProvider;
+
+use core_kernel_classes_Resource;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoLti\models\classes\Platform\LtiPlatform;
+use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
+
+class LtiPlatformFactory extends ConfigurableService
+{
+    public function createFromResource(core_kernel_classes_Resource $resource): LtiPlatform
+    {
+        $propertiesValues = $resource->getPropertiesValues(
+            [
+                RdfLtiPlatformRepository::LTI_PLATFORM_CLIENT_ID,
+                RdfLtiPlatformRepository::LTI_PLATFORM_DEPLOYMENT_ID,
+                RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE,
+                RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL,
+                RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL,
+                RdfLtiPlatformRepository::LTI_TOOL_JWKS_URL,
+            ]
+        );
+
+        return new LtiPlatform(
+            $resource->getUri(),
+            $resource->getLabel(),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_CLIENT_ID]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_DEPLOYMENT_ID]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_TOOL_JWKS_URL]),
+        );
+    }
+}

--- a/models/classes/Platform/Repository/LtiPlatformFactory.php
+++ b/models/classes/Platform/Repository/LtiPlatformFactory.php
@@ -20,11 +20,10 @@
 
 declare(strict_types=1);
 
-namespace oat\taoLti\models\classes\LtiProvider;
+namespace oat\taoLti\models\classes\Platform;
 
 use core_kernel_classes_Resource;
 use oat\oatbox\service\ConfigurableService;
-use oat\taoLti\models\classes\Platform\LtiPlatform;
 use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
 
 class LtiPlatformFactory extends ConfigurableService
@@ -38,7 +37,7 @@ class LtiPlatformFactory extends ConfigurableService
                 RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE,
                 RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL,
                 RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL,
-                RdfLtiPlatformRepository::LTI_TOOL_JWKS_URL,
+                RdfLtiPlatformRepository::LTI_PLATFORM_JWKS_URL,
             ]
         );
 
@@ -50,7 +49,7 @@ class LtiPlatformFactory extends ConfigurableService
             (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE]),
             (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL]),
             (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL]),
-            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_TOOL_JWKS_URL]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_JWKS_URL]),
         );
     }
 }

--- a/models/classes/Platform/Repository/LtiPlatformFactory.php
+++ b/models/classes/Platform/Repository/LtiPlatformFactory.php
@@ -49,7 +49,7 @@ class LtiPlatformFactory extends ConfigurableService
             (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE]),
             (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL]),
             (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL]),
-            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_JWKS_URL]),
+            (string)reset($propertiesValues[RdfLtiPlatformRepository::LTI_PLATFORM_JWKS_URL])
         );
     }
 }

--- a/models/classes/Platform/Repository/LtiPlatformFactory.php
+++ b/models/classes/Platform/Repository/LtiPlatformFactory.php
@@ -20,11 +20,11 @@
 
 declare(strict_types=1);
 
-namespace oat\taoLti\models\classes\Platform;
+namespace oat\taoLti\models\classes\Platform\Repository;
 
 use core_kernel_classes_Resource;
 use oat\oatbox\service\ConfigurableService;
-use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
+use oat\taoLti\models\classes\Platform\LtiPlatform;
 
 class LtiPlatformFactory extends ConfigurableService
 {

--- a/models/classes/Platform/Repository/LtiPlatformRepositoryInterface.php
+++ b/models/classes/Platform/Repository/LtiPlatformRepositoryInterface.php
@@ -28,7 +28,7 @@ use oat\taoLti\models\classes\Platform\LtiPlatform;
  */
 interface LtiPlatformRepositoryInterface extends Countable
 {
-    const SERVICE_ID = 'taoLti/LtiPlatformRepository';
+    public const SERVICE_ID = 'taoLti/LtiPlatformRepository';
 
     /**
      * @return LtiPlatform[]

--- a/models/classes/Platform/Repository/LtiPlatformRepositoryInterface.php
+++ b/models/classes/Platform/Repository/LtiPlatformRepositoryInterface.php
@@ -15,35 +15,36 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
  */
 
-namespace oat\taoLti\models\classes\LtiProvider;
+namespace oat\taoLti\models\classes\Platform\Repository;
 
 use Countable;
+use oat\taoLti\models\classes\Platform\LtiPlatform;
 
 /**
- * Service methods to manage the LTI provider business objects.
+ * Service methods to manage the LTI platform business objects.
  */
-interface LtiProviderRepositoryInterface extends Countable
+interface LtiPlatformRepositoryInterface extends Countable
 {
+    const SERVICE_ID = 'taoLti/LtiPlatformRepository';
+
     /**
      * Returns all providers.
      *
-     * @return LtiProvider[]
+     * @return LtiPlatform[]
      */
     public function findAll(): array;
 
     /**
      * Search all LTI providers with label property containing the given label.
      *
-     * @return LtiProvider[]
+     * @return LtiPlatform[]
      */
     public function searchByLabel(string $label): array;
 
-    public function searchById(string $id): ?LtiProvider;
+    public function searchById(string $id): ?LtiPlatform;
 
-    public function searchByOauthKey(string $oauthKey): ?LtiProvider;
-
-    public function searchByIssuer(string $issuer, ?string $clientId = null): ?LtiProvider;
+    public function searchByIssuer(string $issuer, string $clientId = null): ?LtiPlatform;
 }

--- a/models/classes/Platform/Repository/LtiPlatformRepositoryInterface.php
+++ b/models/classes/Platform/Repository/LtiPlatformRepositoryInterface.php
@@ -31,20 +31,18 @@ interface LtiPlatformRepositoryInterface extends Countable
     const SERVICE_ID = 'taoLti/LtiPlatformRepository';
 
     /**
-     * Returns all providers.
-     *
      * @return LtiPlatform[]
      */
     public function findAll(): array;
 
     /**
-     * Search all LTI providers with label property containing the given label.
-     *
      * @return LtiPlatform[]
      */
     public function searchByLabel(string $label): array;
 
     public function searchById(string $id): ?LtiPlatform;
+
+    public function searchByClientId(string $clientId): ?LtiPlatform;
 
     public function searchByIssuer(string $issuer, string $clientId = null): ?LtiPlatform;
 }

--- a/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
+++ b/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
@@ -24,7 +24,6 @@ use core_kernel_classes_Class;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\OntologyClassService;
-use oat\taoLti\models\classes\Platform\LtiPlatformFactory;
 use oat\taoLti\models\classes\Platform\LtiPlatform;
 use common_exception_Error as ErrorException;
 use core_kernel_classes_Resource as RdfResource;

--- a/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
+++ b/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
@@ -40,7 +40,8 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
     public const LTI_PLATFORM_CLIENT_ID = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformClientId';
     public const LTI_PLATFORM_DEPLOYMENT_ID = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformDeploymentId';
     public const LTI_PLATFORM_AUDIENCE = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformAudience';
-    public const LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOuath2AccessTokenUrl';
+    public const LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL =
+        'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOuath2AccessTokenUrl';
     public const LTI_PLATFORM_OIDC_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOidcAuthenticationUrl';
     public const LTI_PLATFORM_JWKS_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformJwksUrl';
 

--- a/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
+++ b/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ */
+
+namespace oat\taoLti\models\classes\Platform\Repository;
+
+use core_kernel_classes_Class;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\generis\model\OntologyRdfs;
+use oat\tao\model\OntologyClassService;
+use oat\taoLti\models\classes\LtiProvider\LtiPlatformFactory;
+use oat\taoLti\models\classes\Platform\LtiPlatform;
+use common_exception_Error as ErrorException;
+use core_kernel_classes_Resource as RdfResource;
+
+/**
+ * Service methods to manage the LTI 1.3 platform business objects using the RDF API.
+ *
+ * @package taoLti
+ */
+class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatformRepositoryInterface
+{
+    public const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform';
+
+    public const LTI_PLATFORM_CLIENT_ID = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformClientId';
+    public const LTI_PLATFORM_DEPLOYMENT_ID = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformDeploymentId';
+    public const LTI_PLATFORM_AUDIENCE = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformAudience';
+    public const LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOuath2AccessTokenUrl';
+    public const LTI_PLATFORM_OIDC_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOidcAuthenticationUrl';
+    public const LTI_TOOL_JWKS_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformJwksUrl';
+
+    /**
+     * return the group top level class
+     *
+     * @return core_kernel_classes_Class
+     */
+    public function getRootClass()
+    {
+        return $this->getClass(self::CLASS_URI);
+    }
+
+    /**
+     * Returns the number of LtiProviders.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return $this->queryResources([], 'count', 0);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function findAll(): array
+    {
+        return $this->getPlatforms();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function searchByLabel(string $queryString): array
+    {
+        return $this->getPlatforms([OntologyRdfs::RDFS_LABEL => $queryString]);
+    }
+
+    /**
+     * Retrieves LTI platforms from RDF store corresponding to the given criteria.
+     *
+     * @return LtiPlatform[]
+     */
+    private function getPlatforms(array $criteria = []): array
+    {
+        $resources = $this->queryResources($criteria, 'search', []);
+        $ltiProviders = [];
+
+        foreach ($resources as $resource) {
+            $ltiProviders[] = $this->getLtiProviderFromResource($resource);
+        }
+
+        return $ltiProviders;
+    }
+
+    /**
+     * Retrieves resources from rdf store corresponding to the given criteria,
+     * hydrate the result with the $hydration method
+     * or returns $default on failure
+     *
+     * @param array $criteria
+     * @param string $hydration Hydration method ("search" for actual results, "count" for counting results)
+     * @param array|int $default default value to return on failure
+     *
+     * @return mixed
+     */
+    private function queryResources(array $criteria, $hydration, $default)
+    {
+        try {
+            /** @var ComplexSearchService $searchService */
+            $searchService = $this->getServiceLocator()->get(ComplexSearchService::SERVICE_ID);
+            $queryBuilder = $searchService->query();
+            $query = $searchService->searchType($queryBuilder, self::CLASS_URI, true);
+            if (count($criteria)) {
+                foreach ($criteria as $property => $value) {
+                    $query->add($property)->contains($value);
+                }
+            }
+            $queryBuilder->setCriteria($query);
+
+            return $searchService->getGateway()->$hydration($queryBuilder);
+        } catch (ErrorException $e) {
+            $this->logError('Unable to retrieve providers: ' . $e->getMessage());
+
+            return $default;
+        }
+    }
+
+    private function getLtiProviderFromResource(RdfResource $resource): LtiPlatform
+    {
+        return $this->getLtiPlatformFactory()->createFromResource($resource);
+    }
+
+    public function searchById(string $id): ?LtiPlatform
+    {
+        if ($this->getResource($id)->exists()) {
+            return $this->getLtiProviderFromResource($this->getResource($id));
+        }
+        return null;
+    }
+
+    public function searchByClientId(string $clientId): ?LtiPlatform
+    {
+        $platforms = $this->getPlatforms([self::LTI_PLATFORM_CLIENT_ID => $clientId]);
+        $count = count($platforms);
+        if ($count === 0) {
+            return null;
+        }
+        if ($count > 1) {
+            $this->logWarning(sprintf('Found %d LTI platforms with the same clientId: %s', $count, $clientId));
+        }
+        return reset($platforms);
+    }
+
+    public function searchByIssuer(string $issuer, string $clientId = null): ?LtiPlatform
+    {
+        $criteria = [self::LTI_PLATFORM_AUDIENCE => $issuer];
+        if ($clientId !== null) {
+            $criteria[self::LTI_PLATFORM_CLIENT_ID] = $clientId;
+        }
+        $platforms = $this->getPlatforms($criteria);
+        $count = count($platforms);
+        if ($count === 0) {
+            return null;
+        }
+        if ($count > 1) {
+            $this->logWarning(sprintf('Found %d LTI platforms with the same clientId: %s and audience: %s',
+                $count, $clientId, $issuer));
+        }
+        return reset($platforms);
+    }
+
+    private function getLtiPlatformFactory(): LtiPlatformFactory
+    {
+        return $this->getServiceLocator()->get(LtiPlatformFactory::class);
+    }
+}

--- a/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
+++ b/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
@@ -24,7 +24,7 @@ use core_kernel_classes_Class;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\OntologyClassService;
-use oat\taoLti\models\classes\LtiProvider\LtiPlatformFactory;
+use oat\taoLti\models\classes\Platform\LtiPlatformFactory;
 use oat\taoLti\models\classes\Platform\LtiPlatform;
 use common_exception_Error as ErrorException;
 use core_kernel_classes_Resource as RdfResource;
@@ -43,7 +43,7 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
     public const LTI_PLATFORM_AUDIENCE = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformAudience';
     public const LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOuath2AccessTokenUrl';
     public const LTI_PLATFORM_OIDC_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformOidcAuthenticationUrl';
-    public const LTI_TOOL_JWKS_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformJwksUrl';
+    public const LTI_PLATFORM_JWKS_URL = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#PlatformJwksUrl';
 
     /**
      * return the group top level class
@@ -56,8 +56,6 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
     }
 
     /**
-     * Returns the number of LtiProviders.
-     *
      * @return int
      */
     public function count()
@@ -89,13 +87,13 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
     private function getPlatforms(array $criteria = []): array
     {
         $resources = $this->queryResources($criteria, 'search', []);
-        $ltiProviders = [];
+        $ltiPlatforms = [];
 
         foreach ($resources as $resource) {
-            $ltiProviders[] = $this->getLtiProviderFromResource($resource);
+            $ltiPlatforms[] = $this->getLtiPlatformFromResource($resource);
         }
 
-        return $ltiProviders;
+        return $ltiPlatforms;
     }
 
     /**
@@ -125,13 +123,13 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
 
             return $searchService->getGateway()->$hydration($queryBuilder);
         } catch (ErrorException $e) {
-            $this->logError('Unable to retrieve providers: ' . $e->getMessage());
+            $this->logError('Unable to retrieve platforms: ' . $e->getMessage());
 
             return $default;
         }
     }
 
-    private function getLtiProviderFromResource(RdfResource $resource): LtiPlatform
+    private function getLtiPlatformFromResource(RdfResource $resource): LtiPlatform
     {
         return $this->getLtiPlatformFactory()->createFromResource($resource);
     }
@@ -139,7 +137,7 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
     public function searchById(string $id): ?LtiPlatform
     {
         if ($this->getResource($id)->exists()) {
-            return $this->getLtiProviderFromResource($this->getResource($id));
+            return $this->getLtiPlatformFromResource($this->getResource($id));
         }
         return null;
     }

--- a/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
+++ b/models/classes/Platform/Repository/RdfLtiPlatformRepository.php
@@ -166,8 +166,12 @@ class RdfLtiPlatformRepository extends OntologyClassService implements LtiPlatfo
             return null;
         }
         if ($count > 1) {
-            $this->logWarning(sprintf('Found %d LTI platforms with the same clientId: %s and audience: %s',
-                $count, $clientId, $issuer));
+            $this->logWarning(sprintf(
+                'Found %d LTI platforms with the same clientId: %s and audience: %s',
+                $count,
+                $clientId,
+                $issuer
+            ));
         }
         return reset($platforms);
     }

--- a/models/classes/Platform/Validation/ValidationRegistry.php
+++ b/models/classes/Platform/Validation/ValidationRegistry.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Validation;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
+
+class ValidationRegistry extends ConfigurableService
+{
+    private const validators = [
+        RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE => [['NotEmpty']],
+        RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL => [['NotEmpty'], ['Url']],
+        RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL => [['NotEmpty'], ['Url']],
+        RdfLtiPlatformRepository::LTI_TOOL_JWKS_URL => [['NotEmpty'], ['Url']],
+    ];
+
+    public function getValidators(string $field = null): array
+    {
+        if ($field !== null) {
+            return self::validators[$field];
+        }
+        return self::validators;
+    }
+}

--- a/models/classes/Platform/Validation/ValidationRegistry.php
+++ b/models/classes/Platform/Validation/ValidationRegistry.php
@@ -31,7 +31,7 @@ class ValidationRegistry extends ConfigurableService
         RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE => [['NotEmpty']],
         RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL => [['NotEmpty'], ['Url']],
         RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL => [['NotEmpty'], ['Url']],
-        RdfLtiPlatformRepository::LTI_TOOL_JWKS_URL => [['NotEmpty'], ['Url']],
+        RdfLtiPlatformRepository::LTI_PLATFORM_JWKS_URL => [['NotEmpty'], ['Url']],
     ];
 
     public function getValidators(string $field = null): array

--- a/models/classes/Platform/Validation/ValidationRegistry.php
+++ b/models/classes/Platform/Validation/ValidationRegistry.php
@@ -27,7 +27,7 @@ use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
 
 class ValidationRegistry extends ConfigurableService
 {
-    private const validators = [
+    private const VALIDATORS = [
         RdfLtiPlatformRepository::LTI_PLATFORM_AUDIENCE => [['NotEmpty']],
         RdfLtiPlatformRepository::LTI_PLATFORM_OAUTH2_ACCESS_TOKEN_URL => [['NotEmpty'], ['Url']],
         RdfLtiPlatformRepository::LTI_PLATFORM_OIDC_URL => [['NotEmpty'], ['Url']],
@@ -37,8 +37,8 @@ class ValidationRegistry extends ConfigurableService
     public function getValidators(string $field = null): array
     {
         if ($field !== null) {
-            return self::validators[$field];
+            return self::VALIDATORS[$field];
         }
-        return self::validators;
+        return self::VALIDATORS;
     }
 }

--- a/models/classes/Platform/Validation/ValidatorsFactory.php
+++ b/models/classes/Platform/Validation/ValidatorsFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Validation;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\validator\ValidatorInterface;
+use tao_helpers_form_FormFactory;
+use tao_helpers_Uri;
+
+class ValidatorsFactory extends ConfigurableService
+{
+    /**
+     * @return ValidatorInterface[][]
+     */
+    public function createFormValidators(string $field = null): array
+    {
+        $result = [];
+        foreach ($this->getValidationRegistry()->getValidators($field) as $name => $validators) {
+            foreach ($validators as $validator) {
+                $result[tao_helpers_Uri::encode($name)][] = tao_helpers_form_FormFactory::getValidator(...$validator);
+            }
+        }
+        return $result;
+    }
+
+    private function getValidationRegistry(): ValidationRegistry
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(ValidationRegistry::class);
+    }
+}

--- a/models/classes/Platform/Validation/ValidatorsFactory.php
+++ b/models/classes/Platform/Validation/ValidatorsFactory.php
@@ -45,7 +45,6 @@ class ValidatorsFactory extends ConfigurableService
 
     private function getValidationRegistry(): ValidationRegistry
     {
-        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(ValidationRegistry::class);
     }
 }

--- a/models/classes/Security/AccessTokenRequestValidator.php
+++ b/models/classes/Security/AccessTokenRequestValidator.php
@@ -78,9 +78,14 @@ class AccessTokenRequestValidator extends ConfigurableService implements AccessT
         }
 
         if ($this->ltiProvider !== null) {
+            $requestClientId = $result->getRegistration()->getClientId();
             $ltiProvider = $this->getLtiProviderService()->searchByToolClientId(
-                $result->getRegistration()->getClientId()
+                $requestClientId
             );
+
+            if ($ltiProvider === null) {
+                throw new InvalidLtiProviderException(sprintf('Lti provider with client id %s does not exist', $requestClientId));
+            }
 
             if (!$this->isSameLtiProvider($ltiProvider)) {
                 throw new InvalidLtiProviderException('Lti provider from registration is not matching delivery');

--- a/test/unit/models/classes/LtiProvider/LtiProviderServiceTest.php
+++ b/test/unit/models/classes/LtiProvider/LtiProviderServiceTest.php
@@ -24,7 +24,6 @@ namespace oat\taoLti\test\unit\models\classes\LtiProvider;
 
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
-use oat\taoLti\models\classes\LtiProvider\InvalidLtiProviderException;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderRepositoryInterface;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
@@ -109,8 +108,6 @@ class LtiProviderServiceTest extends TestCase
 
     public function testFailingSearchByToolClientId(): void
     {
-        $this->expectException(InvalidLtiProviderException::class);
-
         $provider = $this->createLtiProvider();
         $provider2 = $this->createLtiProvider();
 
@@ -127,7 +124,7 @@ class LtiProviderServiceTest extends TestCase
             ->method('getToolClientId')
             ->willReturn('also_not_this');
 
-        $this->subject->searchByToolClientId('client_id');
+        $this->assertNull($this->subject->searchByToolClientId('client_id'));
     }
 
     /**

--- a/test/unit/models/classes/Platform/LtiPlatformTest.php
+++ b/test/unit/models/classes/Platform/LtiPlatformTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoLti\test\unit\models\classes\Platform;
+
+use oat\generis\test\TestCase;
+use oat\taoLti\models\classes\Platform\LtiPlatform;
+
+class LtiPlatformTest extends TestCase
+{
+    /**
+     * @dataProvider ltiDataProvider
+     */
+    public function testGetters($id, $label, $clientId, $deploymentId, $audience, $oauth2AccessTokenUrl, $oidcAuthenticationUrl, $jwksUrl): void
+    {
+        $subject = new LtiPlatform($id, $label, $clientId, $deploymentId, $audience, $oauth2AccessTokenUrl, $oidcAuthenticationUrl, $jwksUrl);
+
+        $this->assertEquals($id, $subject->getId());
+        $this->assertEquals($label, $subject->getLabel());
+        $this->assertEquals($clientId, $subject->getClientId());
+        $this->assertEquals($deploymentId, $subject->getDeploymentId());
+        $this->assertEquals($audience, $subject->getAudience());
+        $this->assertEquals($oauth2AccessTokenUrl, $subject->getOuath2AccessTokenUrl());
+        $this->assertEquals($oidcAuthenticationUrl, $subject->getOidcAuthenticationUrl());
+        $this->assertEquals($jwksUrl, $subject->getJwksUrl());
+    }
+
+    public function ltiDataProvider(): array
+    {
+        return [
+            ['uid', 'label', 'client_id', 'deployment_id', 'audience', 'http://oauth.aceess/token.url', 'http://oidc.auth.url', 'http://jwks.url'],
+            ['123', '', '', '', 'audience', 'http://oauth.aceess/token.url', 'http://oidc.auth.url', 'http://jwks.url'],
+        ];
+    }
+}

--- a/test/unit/models/classes/Platform/Service/AccessTokenRequestValidatorTest.php
+++ b/test/unit/models/classes/Platform/Service/AccessTokenRequestValidatorTest.php
@@ -115,9 +115,17 @@ class AccessTokenRequestValidatorTest extends TestCase
 
     public function testRegistrationClientNotMatchingDelivery(): void
     {
+        $this->expectException(InvalidLtiProviderException::class);
+
         $registration = $this->createMock(RegistrationInterface::class);
         $ltiProviderService = $this->createMock(LtiProviderService::class);
+        $requestLtiProvider = $this->createMock(LtiProvider::class);
         $ltiProvider = $this->createMock(LtiProvider::class);
+
+        $ltiProviderService
+            ->expects($this->once())
+            ->method('searchByToolClientId')
+            ->willReturn($requestLtiProvider);
 
         $this->subject->setServiceLocator(
             $this->getServiceLocatorMock(

--- a/test/unit/models/classes/Platform/Service/AccessTokenRequestValidatorTest.php
+++ b/test/unit/models/classes/Platform/Service/AccessTokenRequestValidatorTest.php
@@ -115,8 +115,6 @@ class AccessTokenRequestValidatorTest extends TestCase
 
     public function testRegistrationClientNotMatchingDelivery(): void
     {
-        $this->expectException(InvalidLtiProviderException::class);
-
         $registration = $this->createMock(RegistrationInterface::class);
         $ltiProviderService = $this->createMock(LtiProviderService::class);
         $ltiProvider = $this->createMock(LtiProvider::class);

--- a/test/unit/models/classes/Security/AuthorizationServerFactoryTest.php
+++ b/test/unit/models/classes/Security/AuthorizationServerFactoryTest.php
@@ -42,6 +42,9 @@ class AuthorizationServerFactoryTest extends TestCase
 {
     use NoPrivacyTrait;
 
+    private const PRIVATE_KEY_PATH = __DIR__ . '/../../../../../vendor/oat-sa/lib-lti1p3-core/tests/Resource/Key/RSA/private.key';
+    private const PUBLIC_KEY_PATH = __DIR__ . '/../../../../../vendor/oat-sa/lib-lti1p3-core/tests/Resource/Key/RSA/public.key';
+
     private $subject;
 
     private $registrationRepository;
@@ -74,13 +77,13 @@ class AuthorizationServerFactoryTest extends TestCase
 
     public function testCreate()
     {
-        $keyChainPrivateKey = '-----BEGIN RSA PRIVATE KEY-----
-ABC-----END RSA PRIVATE KEY-----';
+        $keyChainPrivateKey = file_get_contents(self::PRIVATE_KEY_PATH);
+        $keyChainPublicKey = file_get_contents(self::PUBLIC_KEY_PATH);
 
         $keyChain = new KeyChain(
             'toto',
             'toto',
-            new Key('toto-public'),
+            new Key($keyChainPublicKey),
             new Key($keyChainPrivateKey)
         );
 
@@ -128,7 +131,8 @@ ABC-----END RSA PRIVATE KEY-----';
 
         $privateKey = $this->getPrivateProperty($authorizationServer, 'privateKey');
         $this->assertInstanceOf(CryptKey::class, $privateKey);
-        $this->assertSame($keyChainPrivateKey, file_get_contents($privateKey->getKeyPath()));
+
+        $this->assertSame($keyChainPrivateKey, $privateKey->getKeyContents());
 
         $this->assertSame(
             'toto',


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-879

## Summary
LTI 1.3 Platforms + Registration repo implemented.

## How to test
At the moment, it's not possible to test the whole workflow including the registration repository, as LTI1.3 isn't implemented, yet.
The only way is to check the UI screen is correct. Here's how to do that:
1. Log in to the BO.
2. Click the 'Gear' icon to open preferences, select 'LTI 1.3 Platform' which should show up with this PR applied.
3. Play around with CRUD on platforms etc, check the validation is implemented correctly.

## Sandbox environment
Deployed on http://cgen-ltiregistrations.playground.kitchen.it.taocloud.org:42141/