### PR TITLE
TR-2256 fix: destroy a pre-existing session before starting an LTI one

### DIFF
--- a/controller/ToolModule.php
+++ b/controller/ToolModule.php
@@ -25,7 +25,7 @@ use common_Exception;
 use common_exception_Error;
 use common_exception_IsAjaxAction;
 use common_http_Request;
-use OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool\ToolLaunchValidator;
+use common_session_SessionManager as SessionManager;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use oat\tao\model\oauth\OauthService;
 use oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator;
@@ -61,6 +61,8 @@ abstract class ToolModule extends LtiModule
      */
     public function launch()
     {
+        SessionManager::endSession();
+
         try {
             $request = common_http_Request::currentRequest();
             $ltiLaunchData = LtiLaunchData::fromRequest($request);


### PR DESCRIPTION
# [TR-2256](https://oat-sa.atlassian.net/browse/TR-2256)

fix: destroy a pre-existing session, which may potentially contain unrelated or sensitive data, before starting an LTI one

## How to test
1. Launch an LTI 1.1 delivery execution with a return URL
2. Launch another LTI 1.1 delivery execution, changing the return URL, and removing a mandatory field (Resource ID)
3. The user agent must no longer be returned to the original return URL

## Example of an invalid behavior

https://user-images.githubusercontent.com/2943256/135317052-31c4330a-f473-4ea3-91e8-bef0fb0034e7.mov