### PR TITLE
fix: incorrect tool validation handling

### DIFF
--- a/models/classes/Tool/Validation/Lti1p3Validator.php
+++ b/models/classes/Tool/Validation/Lti1p3Validator.php
@@ -43,10 +43,6 @@ class Lti1p3Validator extends ConfigurableService
         try {
             $ltiMessagePayload = $this->validateRequest($request);
 
-            if ($ltiMessagePayload === null) {
-                throw new LtiException('No LTI message payload received.');
-            }
-
             $this->validateRole($ltiMessagePayload);
         } catch (Lti1p3Exception $exception) {
             throw new LtiException($exception->getMessage());
@@ -71,7 +67,13 @@ class Lti1p3Validator extends ConfigurableService
             throw new Lti1p3Exception($result->getError());
         }
 
-        return $result->getPayload();
+        $ltiMessagePayload = $result->getPayload();
+
+        if ($ltiMessagePayload === null) {
+            throw new Lti1p3Exception('No LTI message payload received.');
+        }
+
+        return $ltiMessagePayload;
     }
 
     /**

--- a/models/classes/Tool/Validation/Lti1p3Validator.php
+++ b/models/classes/Tool/Validation/Lti1p3Validator.php
@@ -35,6 +35,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class Lti1p3Validator extends ConfigurableService
 {
+    /**
+     * @throws LtiException
+     */
     public function getValidatedPayload(ServerRequestInterface $request): LtiMessagePayloadInterface
     {
         try {
@@ -52,6 +55,9 @@ class Lti1p3Validator extends ConfigurableService
         return $ltiMessagePayload;
     }
 
+    /**
+     * @throws Lti1p3Exception
+     */
     public function validateRequest(ServerRequestInterface $request): LtiMessagePayloadInterface
     {
         $validator = new ToolLaunchValidator(
@@ -59,9 +65,18 @@ class Lti1p3Validator extends ConfigurableService
             new NonceRepository($this->getServiceLocator()->get(ItemPoolSimpleCacheAdapter::class))
         );
 
-        return $validator->validatePlatformOriginatingLaunch($request)->getPayload();
+        $result = $validator->validatePlatformOriginatingLaunch($request);
+
+        if ($result->hasError()) {
+            throw new Lti1p3Exception($result->getError());
+        }
+
+        return $result->getPayload();
     }
 
+    /**
+     * @throws LtiException
+     */
     public function validateRole(LtiMessagePayloadInterface $ltiMessagePayload): void
     {
         $roles = $ltiMessagePayload->getValidatedRoleCollection();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-2279

It fixes this case
```
Fatal error: Uncaught TypeError: Return value of oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator::validateRequest() must implement interface OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface, null returned in /tao/code/taoLti/models/classes/Tool/Validation/Lti1p3Validator.php:62 Stack trace: #0 /tao/code/taoLti/models/classes/Tool/Validation/Lti1p3Validator.php(41): oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator->validateRequest(Object(GuzzleHttp\Psr7\ServerRequest)) #1 /tao/code/taoLti/controller/ToolModule.php(147): oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator->getValidatedPayload(Object(GuzzleHttp\Psr7\ServerRequest)) #2 /tao/code/ltiDeliveryProvider/controller/DeliveryTool.php(188): oat\taoLti\controller\ToolModule->getValidatedLtiMessagePayload() #3 [internal function]: oat\ltiDeliveryProvider\controller\DeliveryTool->launch1p3() #4 /tao/code/tao/models/classes/routing/ActionEnforcer.php(243): call_user_func_array(Array, Array) #5 /tao/code/tao/models/classes/routing/ in /tao/code/taoLti/models/classes/Tool/Validation/Lti1p3Validator.php on line 62
```