### PR TITLE
Feature TR-2281 - configurable LTI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ As a system administrator you can also install it through the TAO Extension Mana
 
 ## Configuration options
 
+### [ServiceOptions.conf.php](../config/generis/ServiceOptions.conf.php)
+
+*Description:* this specifies LTI client configuration.
+
+If the configuration file is not present as
+[`../config/generis/ServiceOptions.conf.php`](../config/generis/ServiceOptions.conf.php), create it by copying from
+[`../generis/config/default/ServiceOptions.conf.php`](../generis/config/default/ServiceOptions.conf.php).
+
+**Example**
+```php
+<?php
+
+return new oat\generis\model\DependencyInjection\ServiceOptions(
+    [
+        oat\taoLti\models\classes\Client\LtiClientFactory::class => [
+            'config' => [    // This configuration accepts
+                'proxy' => [ // [Guzzle Request Options](https://docs.guzzlephp.org/en/stable/request-options.html)
+                    'http'  => 'http://localhost:8125',
+                    'https' => 'https://localhost:9124',
+                ],
+            ],
+        ],
+    ]
+);
+
+```
+
 ### [auth.conf.php](../config/taoLti/auth.conf.php)
 
 #### Configuration option `config`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ As a system administrator you can also install it through the TAO Extension Mana
 
 #### Configuration option `config`
 
-*Description:* this specifies a single option as the `adapter` key of the array. This adapter is to be used to authenticate LTI requests and is retrieved in [FactoryLtiAuthAdapterService](taoLti/models/classes/FactoryLtiAuthAdapterService.php).
+*Description:* this specifies a single option as the `adapter` key of the array. This adapter is to be used to authenticate LTI requests and is retrieved in [FactoryLtiAuthAdapterService](models/classes/FactoryLtiAuthAdapterService.php).
 
 *Possible values of the `adapter` key:* 
 * an instance of any class that implements the `common_user_auth_Adapter` interface

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ As a system administrator you can also install it through the TAO Extension Mana
 
 ## Configuration options
 
-### auth.conf.php
+### [auth.conf.php](../config/taoLti/auth.conf.php)
 
 #### Configuration option `config`
 
@@ -63,7 +63,7 @@ As a system administrator you can also install it through the TAO Extension Mana
 * `['config' => ['adapter' => 'oat\\taoLti\\models\\classes\\LtiAuthAdapter']]`
 
 
-### CookieVerifyService.conf.php
+### [CookieVerifyService.conf.php](../config/taoLti/CookieVerifyService.conf.php)
 
 #### Configuration option `verify_cookie`
 
@@ -73,7 +73,7 @@ As a system administrator you can also install it through the TAO Extension Mana
 * `true`: enable the session check. 2 more HTTP redirects are needed
 * `false`: disable the session check
 
-### LtiUserService.conf.php
+### [LtiUserService.conf.php](../config/taoLti/LtiUserService.conf.php)
 
 #### Configuration option `factoryLtiUser`
 
@@ -104,7 +104,7 @@ As a system administrator you can also install it through the TAO Extension Mana
 *Possible values:* 
 * any unique string
 
-### LtiValidatorService.conf.php
+### [LtiValidatorService.conf.php](../config/taoLti/LtiValidatorService.conf.php)
 
 #### Configuration option `launchDataValidator`
 

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     },
     "require": {
         "ext-openssl": "*",
+        "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/lib-lti1p3-ags": "^1.2",
         "oat-sa/lib-lti1p3-core": "^6.0.0",

--- a/models/classes/Client/LtiClientFactory.php
+++ b/models/classes/Client/LtiClientFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Client;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use oat\generis\model\DependencyInjection\ServiceOptionsInterface;
+
+final class LtiClientFactory
+{
+    /** @var array */
+    private $options;
+
+    public function __construct(ServiceOptionsInterface $options)
+    {
+        $this->options = $options->get(self::class, 'config', []);
+    }
+
+    public function create(): ClientInterface
+    {
+        return new Client($this->options);
+    }
+}

--- a/models/classes/LtiAgs/LtiAgsScoreService.php
+++ b/models/classes/LtiAgs/LtiAgsScoreService.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace oat\taoLti\models\classes\LtiAgs;
 
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactoryInterface;
-use OAT\Library\Lti1p3Ags\Service\Score\Client\ScoreServiceClient;
+use OAT\Library\Lti1p3Ags\Service\Score\ScoreServiceInterface;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\AgsClaim;
@@ -32,13 +32,13 @@ use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 
 class LtiAgsScoreService implements LtiAgsScoreServiceInterface
 {
-    /** @var ScoreServiceClient  */
+    /** @var ScoreServiceInterface  */
     private $scoreServiceClient;
 
     /** @var ScoreFactoryInterface  */
     private $scoreFactory;
 
-    public function __construct(ScoreServiceClient $scoreServiceClient, ScoreFactoryInterface $scoreFactory)
+    public function __construct(ScoreServiceInterface $scoreServiceClient, ScoreFactoryInterface $scoreFactory)
     {
         $this->scoreServiceClient = $scoreServiceClient;
         $this->scoreFactory = $scoreFactory;

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -30,6 +30,7 @@ use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactory;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactoryInterface;
 use OAT\Library\Lti1p3Ags\Service\Score\Client\ScoreServiceClient;
+use OAT\Library\Lti1p3Ags\Service\Score\ScoreServiceInterface;
 use OAT\Library\Lti1p3Core\Security\Jwks\Fetcher\JwksFetcher;
 use OAT\Library\Lti1p3Core\Security\Jwks\Fetcher\JwksFetcherInterface;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Entity\Scope;
@@ -124,7 +125,7 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             );
 
         $services
-            ->set(ScoreServiceClient::class, ScoreServiceClient::class)
+            ->set(ScoreServiceInterface::class, ScoreServiceClient::class)
             ->public();
 
         $services
@@ -136,7 +137,7 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->args(
                 [
-                    service(ScoreServiceClient::class),
+                    service(ScoreServiceInterface::class),
                     service(ScoreFactoryInterface::class)
                 ]
             );

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -22,11 +22,13 @@ declare(strict_types=1);
 
 namespace oat\taoLti\models\classes\ServiceProvider;
 
+use GuzzleHttp\ClientInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\generis\model\DependencyInjection\ServiceOptions;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactory;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactoryInterface;
 use OAT\Library\Lti1p3Ags\Service\Score\Client\ScoreServiceClient;
@@ -43,6 +45,7 @@ use OAT\Library\Lti1p3Core\Service\Client\LtiServiceClientInterface;
 use oat\oatbox\cache\factory\CacheItemPoolFactory;
 use oat\oatbox\cache\ItemPoolSimpleCacheAdapter;
 use oat\oatbox\log\LoggerService;
+use oat\taoLti\models\classes\Client\LtiClientFactory;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsScoreService;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsScoreServiceInterface;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
@@ -65,6 +68,14 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             'defaultScope',
             $_ENV['LTI_DEFAULT_SCOPE'] ?? 'https://purl.imsglobal.org/spec/lti-bo/scope/basicoutcome'
         );
+
+        $services
+            ->set(LtiClientFactory::class)
+            ->args(
+                [
+                    service(ServiceOptions::class),
+                ]
+            );
 
         $services
             ->set(JwksFetcherInterface::class, JwksFetcher::class)
@@ -135,7 +146,9 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
                 [
                     inline_service(CacheItemPoolInterface::class)
                         ->factory([service(CacheItemPoolFactory::class), 'create'])
-                        ->args([[]])
+                        ->args([[]]),
+                    inline_service(ClientInterface::class)
+                        ->factory([service(LtiClientFactory::class), 'create']),
                 ]
             );
 

--- a/test/unit/models/classes/LtiAgsScoreServiceTest.php
+++ b/test/unit/models/classes/LtiAgsScoreServiceTest.php
@@ -26,7 +26,7 @@ namespace oat\taoLti\models\classes;
 use oat\generis\test\TestCase;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactory;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactoryInterface;
-use OAT\Library\Lti1p3Ags\Service\Score\Client\ScoreServiceClient;
+use OAT\Library\Lti1p3Ags\Service\Score\ScoreServiceInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\AgsClaim;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsException;
@@ -36,7 +36,7 @@ class LtiAgsScoreServiceTest extends TestCase
 {
     public function testItSendsAgsClaim(): void
     {
-        $scoreServerClient = $this->createMock(ScoreServiceClient::class);
+        $scoreServerClient = $this->createMock(ScoreServiceInterface::class);
         $scoreFactory = $this->createMock(ScoreFactoryInterface::class);
         $registration = $this->createMock(RegistrationInterface::class);
         $agsClaim = $this->createMock(AgsClaim::class);
@@ -61,7 +61,7 @@ class LtiAgsScoreServiceTest extends TestCase
 
     public function testItThrowsWhenPublishMethodReturnsFalse(): void
     {
-        $scoreServerClient = $this->createMock(ScoreServiceClient::class);
+        $scoreServerClient = $this->createMock(ScoreServiceInterface::class);
         $scoreFactory = $this->createMock(ScoreFactoryInterface::class);
         $registration = $this->createMock(RegistrationInterface::class);
         $agsClaim = $this->createMock(AgsClaim::class);


### PR DESCRIPTION
# [TR-2434](https://oat-sa.atlassian.net/browse/TR-2434)

- fix: rely on `OAT\Library\Lti1p3Ags\Service\Score\ScoreServiceInterface` abstraction, not its implementation throghout the codebase
- chore: link the configuration files, mentioned by `README.md`
- fix: link to `FactoryLtiAuthAdapterService`, mentioned by `README.md`
- feat: initialize LTI client access-token cache
- fix: introduce an explicit dependency on `guzzlehttp/guzzle`, which has already been used in the codebase
- feat: introduce LTI client configuration

## How to test
- [Launch an AGS-claim-containing delivery execution](https://devkit-oat-demo.dev.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=infosignTestToolRegistration&user_list=c3po&launch_url=https://delivery.test-infosign.playground.kitchen.it.taocloud.org/ltiDeliveryProvider/DeliveryTool/launch1p3?delivery%3Dhttp%253A%252F%252Fdelivery.test-infosign.playground.kitchen.it.taocloud.org%252Ftao.rdf%2523i617bd2cea4545185e034c58924ecefcb&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/claim/endpoint%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22scope%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/scope/lineitem%22,%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly%22,%0D%0A%20%20%20%20%20%20%20%20%20%20%20%20%22https://purl.imsglobal.org/spec/lti-ags/scope/score%22%0D%0A%20%20%20%20%20%20%20%20%5D,%0D%0A%20%20%20%20%20%20%20%20%22lineitems%22:%20%22https://enl3ydb5jo2qbra.m.pipedream.net/platform/service/ags/context_id/lineitems%22,%0D%0A%20%20%20%20%20%20%20%20%22lineitem%22:%20%22https://enl3ydb5jo2qbra.m.pipedream.net/platform/service/ags/context_id/lineitems/item_id%22%0D%0A%20%20%20%20%7D%0D%0A%7D), making sure the proxy is set up as per the [`README.md`](https://github.com/oat-sa/extension-tao-lti/blob/feature/TR-2281/configurable-lti-client/README.md#serviceoptionsconfphp) instructions
- Check the client IP of the incoming AGS message

https://user-images.githubusercontent.com/2943256/140347111-061eaf3f-71e7-456f-b2c9-635eadd9fb7a.mov