### PR TITLE
chore: added settings metadata feature flag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "oat-sa/lib-lti1p3-ags": "^1.2",
         "oat-sa/lib-lti1p3-core": "^6.0.0",
         "oat-sa/generis" : ">=15.5.0",
-        "oat-sa/tao-core" : ">=48.39.0"
+        "oat-sa/tao-core" : ">=48.72.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/scripts/install/MapLtiSectionVisibility.php
+++ b/scripts/install/MapLtiSectionVisibility.php
@@ -35,6 +35,9 @@ class MapLtiSectionVisibility extends AbstractAction
                         'settings_manage_lti_keys' => [
                             'FEATURE_FLAG_LTI1P3',
                         ],
+                        'settings_metadata_import' => [
+                            'FEATURE_FLAG_STATISTIC_METADATA_IMPORT'
+                        ]
                     ],
                 ]
             )


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-877


## Notes

This feature flag should not be here, but the initialization of the `SectionVisibilityFilter::SERVICE_ID` and `FeatureFlagFormPropertyMapper::SERVICE_ID` was done here instead of tao-core. taoLti is a client of those classes, therefore should only have options updated, but not registering the service for the first time.

I will open a ticket and ask @bartlomiejmarszal to fix that (https://oat-sa.atlassian.net/browse/AUT-1640), cause it will include fix other migrations and add installations scripts which will increase the scope of my task now.