### PR TITLE
Configuration of SectionVisibilityFilter will not be replaced on install and update

### DIFF
--- a/migrations/Version202009241529173772_taoLti.php
+++ b/migrations/Version202009241529173772_taoLti.php
@@ -66,18 +66,11 @@ final class Version202009241529173772_taoLti extends AbstractMigration
             )
         );
 
-        $this->getServiceManager()->register(
-            SectionVisibilityFilter::SERVICE_ID,
-            new SectionVisibilityFilter(
-                [
-                    SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS => [
-                        'settings_manage_lti_keys' => [
-                            'FEATURE_FLAG_LTI1P3'
-                        ]
-                    ]
-                ]
-            )
-        );
+        $sectionVisibilityFilter = $this->getServiceManager()->get(SectionVisibilityFilter::SERVICE_ID);
+        $featureFlagSections = $sectionVisibilityFilter->getOption(SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS);
+        $featureFlagSections['settings_manage_lti_keys'] = 'FEATURE_FLAG_LTI1P3';
+        $sectionVisibilityFilter->setOption(SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS, $featureFlagSections);
+        $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
     }
 
     public function down(Schema $schema): void

--- a/scripts/install/MapLtiSectionVisibility.php
+++ b/scripts/install/MapLtiSectionVisibility.php
@@ -27,20 +27,17 @@ class MapLtiSectionVisibility extends AbstractAction
 {
     public function __invoke($params)
     {
-        $this->getServiceManager()->register(
-            SectionVisibilityFilter::SERVICE_ID,
-            new SectionVisibilityFilter(
-                [
-                    SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS => [
-                        'settings_manage_lti_keys' => [
-                            'FEATURE_FLAG_LTI1P3',
-                        ],
-                        'settings_metadata_import' => [
-                            'FEATURE_FLAG_STATISTIC_METADATA_IMPORT'
-                        ]
-                    ],
-                ]
-            )
+        $sectionVisibilityFilter = $this->getServiceManager()->get(SectionVisibilityFilter::SERVICE_ID);
+        $featureFlagSections = $sectionVisibilityFilter
+            ->getOption(SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS);
+        $featureFlagSections['settings_manage_lti_keys'] = ['FEATURE_FLAG_LTI1P3'];
+        $featureFlagSections['settings_metadata_import'] = ['FEATURE_FLAG_STATISTIC_METADATA_IMPORT'];
+
+        $sectionVisibilityFilter->setOption(
+            SectionVisibilityFilter::OPTION_FEATURE_FLAG_SECTIONS,
+            $featureFlagSections
         );
+
+        $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
     }
 }


### PR DESCRIPTION
Replaced installation and update scripts to not replace existing SectionVisibilityFilter configs. 