### PR TITLE
Fix / TR-3517 / custom claims to toggle review features

### DIFF
--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -195,11 +195,11 @@ class LtiLaunchData implements \JsonSerializable
 
         // review mode
         if (isset($customParams[self::LTI_SHOW_SCORE])) {
-            $variables[self::LTI_SHOW_SCORE] = true;
+            $variables[self::LTI_SHOW_SCORE] = filter_var($customParams[self::LTI_SHOW_SCORE], FILTER_VALIDATE_BOOLEAN);
         }
 
         if (isset($customParams[self::LTI_SHOW_CORRECT])) {
-            $variables[self::LTI_SHOW_CORRECT] = true;
+            $variables[self::LTI_SHOW_CORRECT] = filter_var($customParams[self::LTI_SHOW_CORRECT], FILTER_VALIDATE_BOOLEAN);
         }
 
         return new static($variables, $customParams);


### PR DESCRIPTION
Fix feature toggling for `custom_show_correct` and `custom_show_score` custom claims.
 
Related to : https://oat-sa.atlassian.net/browse/TR-3517
  
#### How to test
 
- take a test via LTI 1.3, take note of delivery execution id
- configure `config/ltiTestReview/DeliveryExecutionFinderService.conf.php` with:
```
<?php
return new oat\ltiTestReview\models\DeliveryExecutionFinderService(array(
    'show_score' => true,
    'show_correct' => true
));
```
- launch the lti test review with custom claims:
```
"https://purl.imsglobal.org/spec/lti/claim/custom": {
  "execution": "<delivery_execution_id>",
  "custom_show_score": false,
  "custom_show_correct": false
}
```
- verify neither test taker response nor correct answer is shown
