### PR TITLE
feat: create snapshot repository for platform registrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/lib-lti1p3-ags": "^1.2",
         "oat-sa/lib-lti1p3-core": "^6.0.0",
-        "oat-sa/generis" : ">=15.5.0",
+        "oat-sa/generis" : ">=15.18.0",
         "oat-sa/tao-core" : ">=48.72.0"
     },
     "autoload" : {

--- a/controller/PlatformAdmin.php
+++ b/controller/PlatformAdmin.php
@@ -20,7 +20,10 @@
 
 namespace oat\taoLti\controller;
 
+use oat\generis\model\data\event\ResourceCreated;
+use oat\oatbox\event\EventManager;
 use oat\oatbox\validator\ValidatorInterface;
+use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
 use oat\taoLti\models\classes\Platform\Validation\ValidatorsFactory;
 use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
 use tao_actions_SaSModule;
@@ -34,6 +37,18 @@ use tao_actions_SaSModule;
  */
 class PlatformAdmin extends tao_actions_SaSModule
 {
+    public function initialize()
+    {
+        parent::initialize();
+
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->attach(
+            ResourceCreated::class,
+            [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceCreated']
+        );
+    }
+
     /**
      * @inheritDoc
      */

--- a/controller/PlatformAdmin.php
+++ b/controller/PlatformAdmin.php
@@ -15,12 +15,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2021-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\taoLti\controller;
 
 use oat\generis\model\data\event\ResourceCreated;
+use oat\generis\model\data\event\ResourceDeleted;
+use oat\generis\model\data\event\ResourceUpdated;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\validator\ValidatorInterface;
 use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
@@ -29,23 +31,36 @@ use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
 use tao_actions_SaSModule;
 
 /**
- * This controller allows the additon and deletion
- * of LTI 1.3 Platforms
+ * Admin interface for managing LTI 1.3 Platforms entries.
  *
  * @package taoLti
  * @license GPLv2 http://www.opensource.org/licenses/gpl-2.0.php
  */
 class PlatformAdmin extends tao_actions_SaSModule
 {
+    /**
+     * @inheritDoc
+     */
     public function initialize()
     {
         parent::initialize();
 
         /** @var EventManager $eventManager */
         $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+
         $eventManager->attach(
             ResourceCreated::class,
             [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceCreated']
+        );
+
+        $eventManager->attach(
+            ResourceUpdated::class,
+            [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceUpdated']
+        );
+
+        $eventManager->attach(
+            ResourceDeleted::class,
+            [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceDeleted']
         );
     }
 

--- a/controller/PlatformAdmin.php
+++ b/controller/PlatformAdmin.php
@@ -46,21 +46,21 @@ class PlatformAdmin extends tao_actions_SaSModule
         parent::initialize();
 
         /** @var EventManager $eventManager */
-        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager = $this->getPsrContainer()->get(EventManager::class);
 
         $eventManager->attach(
             ResourceCreated::class,
-            [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceCreated']
+            [UpdatePlatformRegistrationSnapshotListener::class, 'whenResourceCreated']
         );
 
         $eventManager->attach(
             ResourceUpdated::class,
-            [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceUpdated']
+            [UpdatePlatformRegistrationSnapshotListener::class, 'whenResourceUpdated']
         );
 
         $eventManager->attach(
             ResourceDeleted::class,
-            [UpdatePlatformRegistrationSnapshotListener::SERVICE_ID, 'whenResourceDeleted']
+            [UpdatePlatformRegistrationSnapshotListener::class, 'whenResourceDeleted']
         );
     }
 

--- a/controller/Security.php
+++ b/controller/Security.php
@@ -77,7 +77,9 @@ class Security extends Controller implements ServiceLocatorAwareInterface
     public function oidcInitiation(): void
     {
         // Create the OIDC initiator
-        $initiator = new OidcInitiator($this->getLti1p3RegistrationRepository());
+        $initiator = new OidcInitiator(
+            $this->getPsrContainer()->get(RegistrationRepositoryInterface::class)
+        );
 
         // Perform the OIDC initiation (including state generation)
         $message = $initiator->initiate($this->getPsrRequest());
@@ -108,11 +110,6 @@ class Security extends Controller implements ServiceLocatorAwareInterface
     private function getOidcLoginAuthenticator(): OidcLoginAuthenticatorInterface
     {
         return $this->getServiceLocator()->get(OidcLoginAuthenticatorProxy::class);
-    }
-
-    private function getLti1p3RegistrationRepository(): RegistrationRepositoryInterface
-    {
-        return $this->getServiceLocator()->get(Lti1p3RegistrationRepository::class);
     }
 
     private function getAccessTokenGenerator(): AccessTokenResponseGeneratorInterface

--- a/migrations/Version202203081458463772_taoLti.php
+++ b/migrations/Version202203081458463772_taoLti.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\taoLti\migrations;

--- a/migrations/Version202203081458463772_taoLti.php
+++ b/migrations/Version202203081458463772_taoLti.php
@@ -7,9 +7,6 @@ namespace oat\taoLti\migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
-use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
-use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
-use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
 
 final class Version202203081458463772_taoLti extends AbstractMigration
 {
@@ -22,36 +19,12 @@ final class Version202203081458463772_taoLti extends AbstractMigration
     {
         $this->createTable($schema);
 
-        $this->getServiceManager()->register(
-            Lti1p3RegistrationRepository::SERVICE_ID,
-            new Lti1p3RegistrationSnapshotRepository(
-                [
-                    Lti1p3RegistrationSnapshotRepository::OPTION_ROOT_URL => ROOT_URL,
-                    Lti1p3RegistrationSnapshotRepository::OPTION_PERSISTENCE_ID => 'default'
-                ]
-            )
-        );
-
-        $this->getServiceManager()->register(
-            UpdatePlatformRegistrationSnapshotListener::SERVICE_ID,
-            new UpdatePlatformRegistrationSnapshotListener()
-        );
+//        $this->syncSnapshotsWithExistingPlatformRegistrations($schema);
     }
 
     public function down(Schema $schema): void
     {
         $schema->dropTable('lti_platform_registration');
-
-        $this->getServiceManager()->register(
-            Lti1p3RegistrationRepository::SERVICE_ID,
-            new Lti1p3RegistrationRepository(
-                [
-                    Lti1p3RegistrationRepository::OPTION_ROOT_URL => ROOT_URL,
-                ]
-            )
-        );
-
-        $this->getServiceManager()->unregister(UpdatePlatformRegistrationSnapshotListener::SERVICE_ID);
     }
 
     private function createTable(Schema $schema): void
@@ -75,5 +48,10 @@ final class Version202203081458463772_taoLti extends AbstractMigration
         $table->addIndex(['audience', 'client_id'], "IDX_audience_client_id");
         $table->addIndex(['client_id'], "IDX_client_id");
         $table->addUniqueIndex(['statement_id'], 'UNQ_statement_id');
+    }
+
+    private function syncSnapshotsWithExistingPlatformRegistrations(Schema $schema): void
+    {
+
     }
 }

--- a/migrations/Version202203081458463772_taoLti.php
+++ b/migrations/Version202203081458463772_taoLti.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace oat\taoLti\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
@@ -19,6 +20,8 @@ final class Version202203081458463772_taoLti extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->createTable($schema);
+
         $this->getServiceManager()->register(
             Lti1p3RegistrationRepository::SERVICE_ID,
             new Lti1p3RegistrationSnapshotRepository(
@@ -33,14 +36,12 @@ final class Version202203081458463772_taoLti extends AbstractMigration
             UpdatePlatformRegistrationSnapshotListener::SERVICE_ID,
             new UpdatePlatformRegistrationSnapshotListener()
         );
-
-        // MetadataModified
-        // ClassDeletedEvent
-        // ResourceDeleted
     }
 
     public function down(Schema $schema): void
     {
+        $schema->dropTable('lti_platform_registration');
+
         $this->getServiceManager()->register(
             Lti1p3RegistrationRepository::SERVICE_ID,
             new Lti1p3RegistrationRepository(
@@ -51,5 +52,28 @@ final class Version202203081458463772_taoLti extends AbstractMigration
         );
 
         $this->getServiceManager()->unregister(UpdatePlatformRegistrationSnapshotListener::SERVICE_ID);
+    }
+
+    private function createTable(Schema $schema): void
+    {
+        $table = $schema->createTable('lti_platform_registration');
+
+        $table->addOption('engine', 'InnoDb');
+
+        $table->addColumn('id', Types::INTEGER, ['unsigned' => true, 'autoincrement' => true, 'notnull' => true]);
+        $table->addColumn('statement_id', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('name', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('audience', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('client_id', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('deployment_id', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('oidc_authentication_url', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('oauth2_access_token_url', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('jwks_url', Types::STRING, ['length' => 255, 'notnull' => true]);
+        $table->addColumn('updated_at', Types::DATETIME_MUTABLE, ['notnull' => true]);
+
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['audience', 'client_id'], "IDX_audience_client_id");
+        $table->addIndex(['client_id'], "IDX_client_id");
+        $table->addUniqueIndex(['statement_id'], 'UNQ_statement_id');
     }
 }

--- a/migrations/Version202203081458463772_taoLti.php
+++ b/migrations/Version202203081458463772_taoLti.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
+use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
+use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
+
+final class Version202203081458463772_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Apply optimized query storage for LTI 1.3 platform registrations';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->getServiceManager()->register(
+            Lti1p3RegistrationRepository::SERVICE_ID,
+            new Lti1p3RegistrationSnapshotRepository(
+                [
+                    Lti1p3RegistrationSnapshotRepository::OPTION_ROOT_URL => ROOT_URL,
+                    Lti1p3RegistrationSnapshotRepository::OPTION_PERSISTENCE_ID => 'default'
+                ]
+            )
+        );
+
+        $this->getServiceManager()->register(
+            UpdatePlatformRegistrationSnapshotListener::SERVICE_ID,
+            new UpdatePlatformRegistrationSnapshotListener()
+        );
+
+        // MetadataModified
+        // ClassDeletedEvent
+        // ResourceDeleted
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->getServiceManager()->register(
+            Lti1p3RegistrationRepository::SERVICE_ID,
+            new Lti1p3RegistrationRepository(
+                [
+                    Lti1p3RegistrationRepository::OPTION_ROOT_URL => ROOT_URL,
+                ]
+            )
+        );
+
+        $this->getServiceManager()->unregister(UpdatePlatformRegistrationSnapshotListener::SERVICE_ID);
+    }
+}

--- a/migrations/Version202203081458463772_taoLti.php
+++ b/migrations/Version202203081458463772_taoLti.php
@@ -12,22 +12,10 @@ final class Version202203081458463772_taoLti extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Apply optimized query storage for LTI 1.3 platform registrations';
+        return 'Create optimized table for querying LTI 1.3 platform registrations';
     }
 
     public function up(Schema $schema): void
-    {
-        $this->createTable($schema);
-
-//        $this->syncSnapshotsWithExistingPlatformRegistrations($schema);
-    }
-
-    public function down(Schema $schema): void
-    {
-        $schema->dropTable('lti_platform_registration');
-    }
-
-    private function createTable(Schema $schema): void
     {
         $table = $schema->createTable('lti_platform_registration');
 
@@ -50,8 +38,8 @@ final class Version202203081458463772_taoLti extends AbstractMigration
         $table->addUniqueIndex(['statement_id'], 'UNQ_statement_id');
     }
 
-    private function syncSnapshotsWithExistingPlatformRegistrations(Schema $schema): void
+    public function down(Schema $schema): void
     {
-
+        $schema->dropTable('lti_platform_registration');
     }
 }

--- a/migrations/Version202203101426253772_taoLti.php
+++ b/migrations/Version202203101426253772_taoLti.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\taoLti\migrations;

--- a/migrations/Version202203101426253772_taoLti.php
+++ b/migrations/Version202203101426253772_taoLti.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
+use oat\taoLti\models\classes\Platform\Repository\LtiPlatformRepositoryInterface;
+
+final class Version202203101426253772_taoLti extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Populate LTI 1.3 platform registration table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var LtiPlatformRepositoryInterface $rdfRepository */
+        $ltiRepository = $this->getServiceLocator()->get(LtiPlatformRepositoryInterface::SERVICE_ID);
+
+        /** @var Lti1p3RegistrationSnapshotRepository $snaptshotRepository */
+        $snapshotRepository = $this->getServiceLocator()->getContainer()->get(RegistrationRepositoryInterface::class);
+
+        foreach ($ltiRepository->findAll() as $registration) {
+            $snapshotRepository->save($registration);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/migrations/Version202203101426253772_taoLti.php
+++ b/migrations/Version202203101426253772_taoLti.php
@@ -30,7 +30,6 @@ use oat\taoLti\models\classes\Platform\Repository\LtiPlatformRepositoryInterface
 
 final class Version202203101426253772_taoLti extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Populate LTI 1.3 platform registration table';
@@ -38,10 +37,10 @@ final class Version202203101426253772_taoLti extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        /** @var LtiPlatformRepositoryInterface $rdfRepository */
+        /** @var LtiPlatformRepositoryInterface $ltiRepository */
         $ltiRepository = $this->getServiceLocator()->get(LtiPlatformRepositoryInterface::SERVICE_ID);
 
-        /** @var Lti1p3RegistrationSnapshotRepository $snaptshotRepository */
+        /** @var Lti1p3RegistrationSnapshotRepository $snapshotRepository */
         $snapshotRepository = $this->getServiceLocator()->getContainer()->get(RegistrationRepositoryInterface::class);
 
         foreach ($ltiRepository->findAll() as $registration) {

--- a/models/classes/LtiService.php
+++ b/models/classes/LtiService.php
@@ -76,13 +76,13 @@ class LtiService extends ConfigurableService
                 $messagePayload->getMandatoryClaim(MessagePayloadInterface::CLAIM_AUD)[0]
             );
 
-            /** @var LtiPlatformRepositoryInterface $platformRepository */
-            $platformRepository = $this->getServiceLocator()->get(LtiPlatformRepositoryInterface::SERVICE_ID);
-            $platform = $platformRepository->searchById($registration->getPlatform()->getIdentifier());
+            $user = new Lti1p3User(
+                LtiLaunchData::fromLti1p3MessagePayload($messagePayload, $registration->getPlatform())
+            );
 
-            $user = new Lti1p3User(LtiLaunchData::fromLti1p3MessagePayload($messagePayload, $platform));
+            $user->setRegistrationId($registration->getIdentifier());
 
-            $session = TaoLtiSession::fromVersion1p3($user->setRegistrationId($registration->getIdentifier()));
+            $session = TaoLtiSession::fromVersion1p3($user);
 
             $this->getServiceLocator()->propagate($session);
 

--- a/models/classes/LtiService.php
+++ b/models/classes/LtiService.php
@@ -28,6 +28,7 @@ use core_kernel_classes_Class;
 use core_kernel_classes_Resource;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
+use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\service\ServiceManager;
@@ -69,12 +70,22 @@ class LtiService extends ConfigurableService
     public function createLti1p3Session(LtiMessagePayloadInterface $messagePayload)
     {
         try {
-            /** @var Lti1p3RegistrationRepository $repository */
-            $repository = $this->getServiceLocator()->get(Lti1p3RegistrationRepository::SERVICE_ID);
-            $registration = $repository->findByPlatformIssuer(
-                $messagePayload->getMandatoryClaim(MessagePayloadInterface::CLAIM_ISS),
-                $messagePayload->getMandatoryClaim(MessagePayloadInterface::CLAIM_AUD)[0]
-            );
+            /** @var RegistrationRepositoryInterface $registrationRepository */
+            $registrationRepository = $this->getServiceLocator()
+                ->getContainer()
+                ->get(RegistrationRepositoryInterface::class);
+
+            $issuer = $messagePayload->getMandatoryClaim(MessagePayloadInterface::CLAIM_ISS);
+            $clientId = $messagePayload->getMandatoryClaim(MessagePayloadInterface::CLAIM_AUD)[0];
+
+            $registration = $registrationRepository->findByPlatformIssuer($issuer, $clientId);
+
+            if ($registration === null) {
+                throw new LtiException(
+                    sprintf('Cannot find a registration with issuer "%s" and client ID "%s"', $issuer, $clientId),
+                    LtiErrorMessage::ERROR_UNAUTHORIZED
+                );
+            }
 
             $user = new Lti1p3User(
                 LtiLaunchData::fromLti1p3MessagePayload($messagePayload, $registration->getPlatform())
@@ -88,8 +99,7 @@ class LtiService extends ConfigurableService
 
             return $session;
         } catch (LtiInvalidVariableException $e) {
-            $this->getServiceLocator()->get(LoggerService::SERVICE_ID)
-                ->log(LogLevel::INFO, $e->getMessage());
+            $this->logInfo($e->getMessage());
 
             throw new LtiException(
                 $e->getMessage(),

--- a/models/classes/Platform/Repository/DefaultToolConfig.php
+++ b/models/classes/Platform/Repository/DefaultToolConfig.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ *
+ * @author Ricardo Quintanilha <ricardo.quintanilha@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Repository;
+
+use OAT\Library\Lti1p3Core\Tool\Tool;
+
+final class DefaultToolConfig
+{
+    private const TOOL_ID = 'tao_tool';
+    private const OIDC_PATH = 'taoLti/Security/oidc';
+    private const JWKS_PATH = 'taoLti/Security/jwks';
+
+    /** @var string */
+    private $baseUri;
+
+    public function __construct(string $baseUri)
+    {
+        $this->baseUri = $baseUri;
+    }
+
+    public function getTool(): Tool
+    {
+        return new Tool(
+            self::TOOL_ID,
+            self::TOOL_ID,
+            rtrim($this->baseUri, '/'),
+            $this->baseUri . self::OIDC_PATH
+        );
+    }
+
+    public function getJwksUrl(): string
+    {
+        return $this->baseUri . self::JWKS_PATH;
+    }
+}

--- a/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Repository;
+
+use common_persistence_SqlPersistence;
+use oat\generis\persistence\PersistenceManager;
+use OAT\Library\Lti1p3Core\Platform\Platform;
+use OAT\Library\Lti1p3Core\Registration\Registration;
+use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
+use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
+use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
+use OAT\Library\Lti1p3Core\Tool\Tool;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
+use oat\taoLti\models\classes\Platform\LtiPlatformRegistration;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\ToolKeyChainRepository;
+
+class Lti1p3RegistrationSnapshotRepository extends ConfigurableService implements RegistrationRepositoryInterface
+{
+    public const OPTION_ROOT_URL = 'rootUrl';
+    public const OPTION_PERSISTENCE_ID = 'persistenceId';
+
+    private const PLATFORM_ID = 'tao';
+    private const TOOL_ID = 'tao_tool';
+    private const OIDC_PATH = 'taoLti/Security/oidc';
+    private const OAUTH_PATH = 'taoLti/Security/oauth';
+    private const JWKS_PATH = 'taoLti/Security/jwks';
+
+    private const TABLE_NAME = 'lti_platform_registration';
+
+    public function save(LtiPlatformRegistration $ltiPlatformRegistration): void
+    {
+        $this->getPersistence()->insert(
+            self::TABLE_NAME,
+            [
+                'statement_id'=> $ltiPlatformRegistration->getIdentifier(),
+                'name' => $ltiPlatformRegistration->getName(),
+                'audience' => $ltiPlatformRegistration->getAudience(),
+                'client_id' => $ltiPlatformRegistration->getClientId(),
+                'deployment_id' => $ltiPlatformRegistration->getDeploymentId(),
+                'oidc_authentication_url' => $ltiPlatformRegistration->getOidcAuthenticationUrl(),
+                'oauth2_access_token_url' => $ltiPlatformRegistration->getOAuth2AccessTokenUrl(),
+                'jwks_url' => $ltiPlatformRegistration->getJwksUrl(),
+                'updated_at' => date('Y-m-d H:i:s')
+            ]
+        );
+    }
+
+    public function find(string $identifier): ?RegistrationInterface
+    {
+        $row = $this->getRow(['statement_id' => $identifier]);
+
+        if (empty($row)) {
+            return null;
+        }
+
+        return $this->toRegistration($row);
+    }
+
+    public function findAll(): array
+    {
+        $rows = $this->getPersistence()
+            ->query('SELECT * FROM lti_platform_registration')
+            ->fetchAll();
+
+        return array_map(
+            function (array $row) {
+                return $this->toRegistration($row);
+            },
+            $rows
+        );
+    }
+
+    public function findByClientId(string $clientId): ?RegistrationInterface
+    {
+        $row = $this->getRow(['client_id' => $clientId]);
+
+        if (empty($row)) {
+            return null;
+        }
+
+        return $this->toRegistration($row);
+    }
+
+    public function findByPlatformIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
+    {
+        $queryParams = [
+            'audience' => $issuer,
+            'client_id' => $clientId
+        ];
+
+        $row = $this->getRow($queryParams);
+
+        if (empty($row)) {
+            return null;
+        }
+
+        return $this->toRegistration($row);
+    }
+
+    public function findByToolIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
+    {
+    }
+
+    private function getRow(array $queryParams = []): array
+    {
+        $queryParams = array_filter($queryParams);
+
+        $query = 'SELECT * FROM lti_platform_registration';
+
+        if (!empty($queryParams)) {
+            $whereClauses = array_map(
+                function ($column) {
+                    return sprintf('%s = :%s', $column, $column);
+                },
+                array_keys($queryParams)
+            );
+
+            $query .= ' WHERE ' . implode(' AND ', $whereClauses);
+        }
+
+        $query .= ' LIMIT 1';
+
+        $statement = $this->getPersistence()->query(
+            $query,
+            $queryParams
+        );
+
+        return $statement->fetch();
+    }
+
+    private function getTool(LtiProvider $ltiProvider): Tool
+    {
+        return new Tool(
+            $ltiProvider->getToolIdentifier(),
+            $ltiProvider->getToolName(),
+            $ltiProvider->getToolAudience(),
+            $ltiProvider->getToolOidcLoginInitiationUrl(),
+            $ltiProvider->getToolLaunchUrl()
+        );
+    }
+
+    private function getDefaultPlatform(): Platform
+    {
+        return new Platform(
+            self::PLATFORM_ID,
+            self::PLATFORM_ID,
+            rtrim($this->getOption(self::OPTION_ROOT_URL), '/'),
+            $this->getOption(self::OPTION_ROOT_URL) . self::OIDC_PATH,
+            $this->getOption(self::OPTION_ROOT_URL) . self::OAUTH_PATH
+        );
+    }
+
+    private function getDefaultTool(): Tool
+    {
+        return new Tool(
+            self::TOOL_ID,
+            self::TOOL_ID,
+            rtrim($this->getOption(self::OPTION_ROOT_URL), '/'),
+            $this->getOption(self::OPTION_ROOT_URL) . self::OIDC_PATH
+        );
+    }
+
+    private function toRegistration(array $row): ?Registration
+    {
+        $toolKeyChain = $this->getCachedPlatformKeyChainRepository()
+            ->find($this->getPlatformKeyChainRepository()->getDefaultKeyId());
+
+        $platform = new Platform(
+            $row['statement_id'],
+            $row['name'],
+            $row['audience'],
+            $row['oidc_authentication_url'],
+            $row['oauth2_access_token_url']
+        );
+
+        return new Registration(
+            $platform->getIdentifier(),
+            $row['client_id'],
+            $platform,
+            $this->getDefaultTool(),
+            [$row['deployment_id']],
+            null,
+            $toolKeyChain,
+            $row['jwks_url'],
+            $this->getOption(self::OPTION_ROOT_URL) . self::JWKS_PATH
+        );
+    }
+
+    private function getPersistence(): common_persistence_SqlPersistence
+    {
+        return $this->getServiceLocator()->get(PersistenceManager::SERVICE_ID)
+            ->getPersistenceById($this->getOption(self::OPTION_PERSISTENCE_ID));
+    }
+
+    private function getCachedPlatformKeyChainRepository(): KeyChainRepositoryInterface
+    {
+        return $this->getServiceLocator()->get(CachedPlatformKeyChainRepository::class);
+    }
+
+    private function getPlatformKeyChainRepository(): PlatformKeyChainRepository
+    {
+        return $this->getServiceLocator()->get(PlatformKeyChainRepository::class);
+    }
+}

--- a/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
@@ -15,7 +15,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ *
+ * @author Ricardo Quintanilha <ricardo.quintanilha@taotesting.com>
  */
 
 declare(strict_types=1);
@@ -31,6 +33,7 @@ use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
 use oat\taoLti\models\classes\Platform\LtiPlatformRegistration;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use RuntimeException;
 
 class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInterface
 {
@@ -108,6 +111,14 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
         );
     }
 
+    public function deleteByStatementId(string $statementId): void
+    {
+        $this->getPersistence()->exec(
+            'DELETE FROM lti_platform_registration WHERE statement_id = :statement_id',
+            ['statement_id' => $statementId]
+        );
+    }
+
     public function find(string $identifier): ?RegistrationInterface
     {
         $row = $this->getRow(['statement_id' => $identifier]);
@@ -162,6 +173,7 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
 
     public function findByToolIssuer(string $issuer, string $clientId = null): ?RegistrationInterface
     {
+        throw new RuntimeException('Find registration by tool is not supported');
     }
 
     private function getRow(array $queryParams = []): array
@@ -189,14 +201,6 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
         );
 
         return $statement->fetch() ?: [];
-    }
-
-    public function deleteByStatementId(string $statementId): void
-    {
-        $this->getPersistence()->exec(
-            'DELETE FROM lti_platform_registration WHERE statement_id = :statement_id',
-            ['statement_id' => $statementId]
-        );
     }
 
     private function toRegistration(array $row): ?Registration

--- a/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
+++ b/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ *
+ * @author Ricardo Quintanilha <ricardo.quintanilha@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Platform\Service;
+
+use oat\generis\model\data\event\ResourceCreated;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
+use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
+use oat\taoLti\models\classes\Platform\Repository\LtiPlatformFactory;
+
+class UpdatePlatformRegistrationSnapshotListener extends ConfigurableService
+{
+    public const SERVICE_ID = 'taoLti/UpdatePlatformRegistrationSnapshotListener';
+
+    public function whenResourceCreated(ResourceCreated $event): void
+    {
+        $ltiPlatformRegistration = $this->getLtiPlatformFactory()
+            ->createFromResource($event->getResource());
+
+        $this->getRepository()->save($ltiPlatformRegistration);
+    }
+
+    private function getLtiPlatformFactory(): LtiPlatformFactory
+    {
+        return $this->getServiceLocator()->get(LtiPlatformFactory::class);
+    }
+
+    private function getRepository(): Lti1p3RegistrationSnapshotRepository
+    {
+        return $this->getServiceLocator()->get(Lti1p3RegistrationRepository::SERVICE_ID);
+    }
+}

--- a/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
+++ b/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
@@ -27,43 +27,41 @@ namespace oat\taoLti\models\classes\Platform\Service;
 use oat\generis\model\data\event\ResourceCreated;
 use oat\generis\model\data\event\ResourceDeleted;
 use oat\generis\model\data\event\ResourceUpdated;
-use oat\oatbox\service\ConfigurableService;
-use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
 use oat\taoLti\models\classes\Platform\Repository\LtiPlatformFactory;
 
-class UpdatePlatformRegistrationSnapshotListener extends ConfigurableService
+class UpdatePlatformRegistrationSnapshotListener
 {
-    public const SERVICE_ID = 'taoLti/UpdatePlatformRegistrationSnapshotListener';
+    /** @var Lti1p3RegistrationSnapshotRepository */
+    private $registrationSnapshotRepository;
+
+    /** @var LtiPlatformFactory */
+    private $ltiPlatformFactory;
+
+    public function __construct(
+        Lti1p3RegistrationSnapshotRepository $registrationSnapshotRepository,
+        LtiPlatformFactory $ltiPlatformFactory
+    ) {
+        $this->registrationSnapshotRepository = $registrationSnapshotRepository;
+        $this->ltiPlatformFactory = $ltiPlatformFactory;
+    }
 
     public function whenResourceCreated(ResourceCreated $event): void
     {
-        $ltiPlatformRegistration = $this->getLtiPlatformFactory()
-            ->createFromResource($event->getResource());
+        $ltiPlatformRegistration = $this->ltiPlatformFactory->createFromResource($event->getResource());
 
-        $this->getRepository()->save($ltiPlatformRegistration);
+        $this->registrationSnapshotRepository->save($ltiPlatformRegistration);
     }
 
     public function whenResourceUpdated(ResourceUpdated $event): void
     {
-        $ltiPlatformRegistration = $this->getLtiPlatformFactory()
-            ->createFromResource($event->getResource());
+        $ltiPlatformRegistration = $this->ltiPlatformFactory->createFromResource($event->getResource());
 
-        $this->getRepository()->save($ltiPlatformRegistration);
+        $this->registrationSnapshotRepository->save($ltiPlatformRegistration);
     }
 
     public function whenResourceDeleted(ResourceDeleted $event): void
     {
-        $this->getRepository()->deleteByStatementId($event->getId());
-    }
-
-    private function getLtiPlatformFactory(): LtiPlatformFactory
-    {
-        return $this->getServiceLocator()->get(LtiPlatformFactory::class);
-    }
-
-    private function getRepository(): Lti1p3RegistrationSnapshotRepository
-    {
-        return $this->getServiceLocator()->get(Lti1p3RegistrationRepository::SERVICE_ID);
+        $this->registrationSnapshotRepository->deleteByStatementId($event->getId());
     }
 }

--- a/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
+++ b/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 namespace oat\taoLti\models\classes\Platform\Service;
 
 use oat\generis\model\data\event\ResourceCreated;
+use oat\generis\model\data\event\ResourceDeleted;
+use oat\generis\model\data\event\ResourceUpdated;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
@@ -40,6 +42,19 @@ class UpdatePlatformRegistrationSnapshotListener extends ConfigurableService
             ->createFromResource($event->getResource());
 
         $this->getRepository()->save($ltiPlatformRegistration);
+    }
+
+    public function whenResourceUpdated(ResourceUpdated $event): void
+    {
+        $ltiPlatformRegistration = $this->getLtiPlatformFactory()
+            ->createFromResource($event->getResource());
+
+        $this->getRepository()->save($ltiPlatformRegistration);
+    }
+
+    public function whenResourceDeleted(ResourceDeleted $event): void
+    {
+        $this->getRepository()->deleteByStatementId($event->getId());
     }
 
     private function getLtiPlatformFactory(): LtiPlatformFactory

--- a/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
+++ b/models/classes/Platform/Service/UpdatePlatformRegistrationSnapshotListener.php
@@ -24,11 +24,14 @@ declare(strict_types=1);
 
 namespace oat\taoLti\models\classes\Platform\Service;
 
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource as Resource;
 use oat\generis\model\data\event\ResourceCreated;
 use oat\generis\model\data\event\ResourceDeleted;
 use oat\generis\model\data\event\ResourceUpdated;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
 use oat\taoLti\models\classes\Platform\Repository\LtiPlatformFactory;
+use oat\taoLti\models\classes\Platform\Repository\RdfLtiPlatformRepository;
 
 class UpdatePlatformRegistrationSnapshotListener
 {
@@ -48,6 +51,10 @@ class UpdatePlatformRegistrationSnapshotListener
 
     public function whenResourceCreated(ResourceCreated $event): void
     {
+        if (!$this->supports($event->getResource())) {
+            return;
+        }
+
         $ltiPlatformRegistration = $this->ltiPlatformFactory->createFromResource($event->getResource());
 
         $this->registrationSnapshotRepository->save($ltiPlatformRegistration);
@@ -55,6 +62,10 @@ class UpdatePlatformRegistrationSnapshotListener
 
     public function whenResourceUpdated(ResourceUpdated $event): void
     {
+        if (!$this->supports($event->getResource())) {
+            return;
+        }
+
         $ltiPlatformRegistration = $this->ltiPlatformFactory->createFromResource($event->getResource());
 
         $this->registrationSnapshotRepository->save($ltiPlatformRegistration);
@@ -63,5 +74,12 @@ class UpdatePlatformRegistrationSnapshotListener
     public function whenResourceDeleted(ResourceDeleted $event): void
     {
         $this->registrationSnapshotRepository->deleteByStatementId($event->getId());
+    }
+
+    private function supports(Resource $resource): bool
+    {
+        return $resource->hasType(
+            new core_kernel_classes_Class(RdfLtiPlatformRepository::CLASS_URI)
+        );
     }
 }

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -37,7 +37,6 @@ use OAT\Library\Lti1p3Ags\Service\Score\ScoreServiceInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\Jwks\Fetcher\JwksFetcher;
 use OAT\Library\Lti1p3Core\Security\Jwks\Fetcher\JwksFetcherInterface;
-use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Entity\Scope;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Factory\AuthorizationServerFactory;
 use OAT\Library\Lti1p3Core\Security\OAuth2\Repository\AccessTokenRepository;
@@ -52,7 +51,6 @@ use oat\taoLti\models\classes\Client\LtiClientFactory;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsScoreService;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsScoreServiceInterface;
 use oat\taoLti\models\classes\Platform\Repository\DefaultToolConfig;
-use oat\taoLti\models\classes\Platform\Repository\DefaultToolConfigFactory;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
 use oat\taoLti\models\classes\Platform\Repository\LtiPlatformFactory;

--- a/models/classes/Tool/Validation/Lti1p3Validator.php
+++ b/models/classes/Tool/Validation/Lti1p3Validator.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -31,7 +31,6 @@ use OAT\Library\Lti1p3Core\Security\Nonce\NonceRepository;
 use oat\oatbox\cache\ItemPoolSimpleCacheAdapter;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoLti\models\classes\LtiException;
-use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
 use Psr\Http\Message\ServerRequestInterface;
 
 class Lti1p3Validator extends ConfigurableService

--- a/models/classes/Tool/Validation/Lti1p3Validator.php
+++ b/models/classes/Tool/Validation/Lti1p3Validator.php
@@ -25,6 +25,7 @@ namespace oat\taoLti\models\classes\Tool\Validation;
 use OAT\Library\Lti1p3Core\Exception\LtiException as Lti1p3Exception;
 use OAT\Library\Lti1p3Core\Message\Launch\Validator\Tool\ToolLaunchValidator;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
+use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Role\RoleInterface;
 use OAT\Library\Lti1p3Core\Security\Nonce\NonceRepository;
 use oat\oatbox\cache\ItemPoolSimpleCacheAdapter;
@@ -57,7 +58,7 @@ class Lti1p3Validator extends ConfigurableService
     public function validateRequest(ServerRequestInterface $request): LtiMessagePayloadInterface
     {
         $validator = new ToolLaunchValidator(
-            $this->getServiceLocator()->get(Lti1p3RegistrationRepository::SERVICE_ID),
+            $this->getRegistrationRepository(),
             new NonceRepository($this->getServiceLocator()->get(ItemPoolSimpleCacheAdapter::class))
         );
 
@@ -86,5 +87,10 @@ class Lti1p3Validator extends ConfigurableService
         if (!$roles->canFindBy(RoleInterface::TYPE_CONTEXT)) {
             throw new LtiException('No valid IMS context role has been provided.');
         }
+    }
+
+    private function getRegistrationRepository(): RegistrationRepositoryInterface
+    {
+        return $this->getServiceLocator()->getContainer()->get(RegistrationRepositoryInterface::class);
     }
 }


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-3666

## Summary
The current implementation of the LTI 1.3 platform registrations store ([Lti1p3RegistrationRepository.php](https://github.com/oat-sa/extension-tao-lti/blob/0aee2cd3de200d4727ec03861e0c81b41ddbfb3f/models/classes/Platform/Repository/Lti1p3RegistrationRepository.php)) reuses RDF store (triples), which may be quite slow when it comes down to selecting a record, based on anything but its ID.
During the OIDC launch flow, the LTI messages have to be verified, and the platform records are searched through by audience value, making the request quite slow.

This PR Introduces a dedicated table to store and retrieve the LTI 1.3 platform registrations.

## How to test
### Pre-requisites
- LTI 1.3 integration using TAO Terre as a Tool
 
1. Launch a test through LTI 1.3

## Dependencies
- https://github.com/oat-sa/generis/pull/993

## Sandbox environment
https://delivery.test-infosign.playground.kitchen.it.taocloud.org/