### PR TITLE
DEFAULT_ANONYMOUS_INTERFACE_LANG for anonymous user

### DIFF
--- a/models/classes/user/Lti1p3User.php
+++ b/models/classes/user/Lti1p3User.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2022 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -42,7 +42,7 @@ class Lti1p3User extends LtiUser
     {
         $userUri = $launchData->hasVariable(LtiLaunchData::USER_ID)
             ? $launchData->getVariable(LtiLaunchData::USER_ID)
-            : 'anonymous';
+            : self::ANONYMOUS_USER_URI;
 
         parent::__construct($launchData, $userUri);
     }

--- a/models/classes/user/LtiUser.php
+++ b/models/classes/user/LtiUser.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  *
  */
@@ -42,6 +42,8 @@ use oat\oatbox\user\UserLanguageService;
 class LtiUser extends \common_user_User implements ServiceLocatorAwareInterface, \JsonSerializable, LtiUserInterface
 {
     use ServiceLocatorAwareTrait;
+
+    public const ANONYMOUS_USER_URI = 'anonymous';
 
     const USER_IDENTIFIER = 'identifier';
 
@@ -156,7 +158,14 @@ class LtiUser extends \common_user_User implements ServiceLocatorAwareInterface,
                 $launchLanguage = $this->getLaunchData()->getLaunchLanguage();
                 $this->language = LtiUtils::mapCode2InterfaceLanguage($launchLanguage);
             } else {
-                $this->language = $this->getServiceLocator()->get(UserLanguageService::SERVICE_ID)->getDefaultLanguage();
+                if (
+                    $this->userUri == self::ANONYMOUS_USER_URI
+                    && defined('DEFAULT_ANONYMOUS_INTERFACE_LANG')
+                ) {
+                    $this->language = DEFAULT_ANONYMOUS_INTERFACE_LANG;
+                } else {
+                    $this->language = $this->getServiceLocator()->get(UserLanguageService::SERVICE_ID)->getDefaultLanguage();
+                }
             }
         }
         return $this->language;

--- a/test/unit/models/classes/LtiAgsScoreServiceTest.php
+++ b/test/unit/models/classes/LtiAgsScoreServiceTest.php
@@ -26,6 +26,7 @@ namespace oat\taoLti\models\classes;
 use oat\generis\test\TestCase;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactory;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactoryInterface;
+use OAT\Library\Lti1p3Ags\Service\Score\Client\ScoreServiceClient;
 use OAT\Library\Lti1p3Ags\Service\Score\ScoreServiceInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\AgsClaim;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
@@ -36,7 +37,7 @@ class LtiAgsScoreServiceTest extends TestCase
 {
     public function testItSendsAgsClaim(): void
     {
-        $scoreServerClient = $this->createMock(ScoreServiceInterface::class);
+        $scoreServerClient = $this->createMock(ScoreServiceClient::class);
         $scoreFactory = $this->createMock(ScoreFactoryInterface::class);
         $registration = $this->createMock(RegistrationInterface::class);
         $agsClaim = $this->createMock(AgsClaim::class);
@@ -61,7 +62,7 @@ class LtiAgsScoreServiceTest extends TestCase
 
     public function testItThrowsWhenPublishMethodReturnsFalse(): void
     {
-        $scoreServerClient = $this->createMock(ScoreServiceInterface::class);
+        $scoreServerClient = $this->createMock(ScoreServiceClient::class);
         $scoreFactory = $this->createMock(ScoreFactoryInterface::class);
         $registration = $this->createMock(RegistrationInterface::class);
         $agsClaim = $this->createMock(AgsClaim::class);


### PR DESCRIPTION
# [TR-4257](https://oat-sa.atlassian.net/browse/TR-4257)

## Summary
Goal is to provide usage DEFAULT_ANONYMOUS_INTERFACE_LANG constant at lti launch by anonymous user

## How to test
- install branch
- update in `config/generis.conf.php` constant `DEFAULT_ANONYMOUS_INTERFACE_LANG` by language other than defined in `DEFAULT_LANG` (for example `ja-JP`)
- launch execution through Lti 1.3 as anonymous user (no user identifier provided in launch data)
- interface language should be overwriten by `DEFAULT_ANONYMOUS_INTERFACE_LANG`
