### PR TITLE
feat: use user login as user identity

### DIFF
--- a/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticator.php
+++ b/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticator.php
@@ -30,10 +30,8 @@ use OAT\Library\Lti1p3Core\Security\User\Result\UserAuthenticationResultInterfac
 use OAT\Library\Lti1p3Core\Security\User\UserAuthenticatorInterface;
 use OAT\Library\Lti1p3Core\User\UserIdentity;
 use oat\oatbox\service\ConfigurableService;
-use oat\oatbox\user\AnonymousUser;
 use oat\oatbox\user\User;
 use oat\oatbox\user\UserService;
-use oat\taoDeliveryRdf\model\guest\GuestTestUser;
 use Throwable;
 
 class Lti1p3UserAuthenticator extends ConfigurableService implements UserAuthenticatorInterface
@@ -61,9 +59,8 @@ class Lti1p3UserAuthenticator extends ConfigurableService implements UserAuthent
             throw new ErrorException(sprintf('User [%s] not found', $userId));
         }
 
-        $login = $user instanceof AnonymousUser || $user instanceof GuestTestUser ?
-            $userId :
-            $this->getPropertyValue($user, UserRdf::PROPERTY_LOGIN);
+        $login = $this->getPropertyValue($user, UserRdf::PROPERTY_LOGIN);
+        $login = empty($login) ? $userId : $login;
 
         $fullName = $this->getPropertyValue($user, UserRdf::PROPERTY_FIRSTNAME)
             . ' ' . $this->getPropertyValue($user, UserRdf::PROPERTY_LASTNAME);

--- a/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticator.php
+++ b/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticator.php
@@ -23,21 +23,25 @@ declare(strict_types=1);
 namespace oat\taoLti\models\classes\Platform\Service\Oidc;
 
 use ErrorException;
-use oat\generis\model\GenerisRdf;
+use oat\generis\model\user\UserRdf;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Security\User\Result\UserAuthenticationResult;
 use OAT\Library\Lti1p3Core\Security\User\Result\UserAuthenticationResultInterface;
 use OAT\Library\Lti1p3Core\Security\User\UserAuthenticatorInterface;
 use OAT\Library\Lti1p3Core\User\UserIdentity;
 use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\user\AnonymousUser;
 use oat\oatbox\user\User;
 use oat\oatbox\user\UserService;
+use oat\taoDeliveryRdf\model\guest\GuestTestUser;
 use Throwable;
 
 class Lti1p3UserAuthenticator extends ConfigurableService implements UserAuthenticatorInterface
 {
-    public function authenticate(RegistrationInterface $registration, string $loginHint): UserAuthenticationResultInterface
-    {
+    public function authenticate(
+        RegistrationInterface $registration,
+        string $loginHint
+    ): UserAuthenticationResultInterface {
         try {
             return new UserAuthenticationResult(true, $this->getUserIdentity($loginHint));
         } catch (Throwable $exception) {
@@ -57,12 +61,21 @@ class Lti1p3UserAuthenticator extends ConfigurableService implements UserAuthent
             throw new ErrorException(sprintf('User [%s] not found', $userId));
         }
 
-        $fullName = (string)($user->getPropertyValues(GenerisRdf::PROPERTY_USER_FIRSTNAME)[0] ?? null)
-            . ' ' . (string)($user->getPropertyValues(GenerisRdf::PROPERTY_USER_LASTNAME)[0] ?? null);
+        $login = $user instanceof AnonymousUser || $user instanceof GuestTestUser ?
+            $userId :
+            $this->getPropertyValue($user, UserRdf::PROPERTY_LOGIN);
 
-        $email = (string)($user->getPropertyValues(GenerisRdf::PROPERTY_USER_MAIL)[0] ?? null);
+        $fullName = $this->getPropertyValue($user, UserRdf::PROPERTY_FIRSTNAME)
+            . ' ' . $this->getPropertyValue($user, UserRdf::PROPERTY_LASTNAME);
 
-        return new UserIdentity($userId, $fullName, $email);
+        $email = $this->getPropertyValue($user, UserRdf::PROPERTY_MAIL);
+
+        return new UserIdentity($login, trim($fullName), $email);
+    }
+
+    private function getPropertyValue(User $user, string $propertyName): string
+    {
+        return (string)($user->getPropertyValues($propertyName)[0] ?? null);
     }
 
     private function getUserService(): UserService

--- a/test/unit/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticatorTest.php
+++ b/test/unit/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticatorTest.php
@@ -22,12 +22,11 @@ declare(strict_types=1);
 
 namespace oat\taoLti\test\unit\models\classes\Platform\Service\Oidc;
 
+use core_kernel_users_GenerisUser;
 use oat\generis\test\ServiceManagerMockTrait;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Security\User\Result\UserAuthenticationResult;
 use OAT\Library\Lti1p3Core\User\UserIdentity;
-use oat\oatbox\user\AnonymousUser;
-use oat\oatbox\user\User;
 use oat\oatbox\user\UserService;
 use oat\taoLti\models\classes\Platform\Service\Oidc\Lti1p3UserAuthenticator;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -110,7 +109,7 @@ class Lti1p3UserAuthenticatorTest extends TestCase
 
     private function expectUser(array $roles, string $login, string $firstName, string $lastName, string $email): void
     {
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(core_kernel_users_GenerisUser::class);
 
         $user->method('getRoles')
             ->willReturn($roles);
@@ -130,7 +129,7 @@ class Lti1p3UserAuthenticatorTest extends TestCase
 
     private function expectAnonymousUser(array $roles): void
     {
-        $user = $this->createMock(AnonymousUser::class);
+        $user = $this->createMock(core_kernel_users_GenerisUser::class);
 
         $user->method('getRoles')
             ->willReturn($roles);

--- a/test/unit/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticatorTest.php
+++ b/test/unit/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticatorTest.php
@@ -127,6 +127,7 @@ class Lti1p3UserAuthenticatorTest extends TestCase
             ->method('getUser')
             ->willReturn($user);
     }
+
     private function expectAnonymousUser(array $roles): void
     {
         $user = $this->createMock(AnonymousUser::class);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-4941

# Goal

Use user login instead or URI as identifier, so it can later be user by data store + tao insights

# How to test

- Launch a test from CG using LTI 1.3 and change the token contents

# Example how it worked: 

OIDC token

`
eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjFfMCJ9.eyJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9yZXNvdXJjZV9saW5rIjp7ImlkIjoiYTc1YzllNmJhNjE5In0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3ZlcnNpb24iOiIxLjMuMCIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL21lc3NhZ2VfdHlwZSI6Ikx0aVJlc291cmNlTGlua1JlcXVlc3QiLCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9kZXBsb3ltZW50X2lkIjoiMSIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3RhcmdldF9saW5rX3VyaSI6Imh0dHBzOi8vZGVsaXZlci5kb2NrZXIubG9jYWxob3N0L2FwaS92MS9hdXRoL2xhdW5jaC1sdGktMXAzL2E3NWM5ZTZiYTYxOSIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3JvbGVzIjpbIkxlYXJuZXIiXSwicmVnaXN0cmF0aW9uX2lkIjoiMV8wIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYm8vY2xhaW0vYmFzaWNvdXRjb21lIjp7Imxpc19yZXN1bHRfc291cmNlZGlkIjoiaHR0cDovL2JhY2tvZmZpY2UuZG9ja2VyLmxvY2FsaG9zdC9vbnRvbG9naWVzL3Rhby5yZGYjaTYzYjU4ODIyYTY5YjgxMzAzYTM3YzZlZDI5ODk3YWU2MiIsImxpc19vdXRjb21lX3NlcnZpY2VfdXJsIjoiaHR0cDovL2JhY2tvZmZpY2UuZG9ja2VyLmxvY2FsaG9zdC90YW9MdGlDb25zdW1lci9SZXN1bHRDb250cm9sbGVyL21hbmFnZVJlc3VsdHMifSwibm9uY2UiOiJjOTg3N2Q5Zi1jYjRkLTQwMWQtYmU2Zi01MWNjZmQyMTc3YTYiLCJqdGkiOiJjOTI3MjBhYS0zNGEzLTRjZmEtOGNmNy1jYjQ4ZmFiZGE5ZmQiLCJpYXQiOjE2NzI5MDU0MTMuMTc0MDczLCJuYmYiOjE2NzI5MDU0MTMuMTc0MDczLCJleHAiOjE2NzI5MDYwMTMuMTc0MDczLCJpc3MiOiJodHRwOi8vYmFja29mZmljZS5kb2NrZXIubG9jYWxob3N0IiwiYXVkIjoiYmFja29mZmljZS1kZWxpdmVyLWlkIiwic3ViIjoiZ2FicmllbCIsIm5hbWUiOiJHYWJyaWVsIFNvYXJlcyIsImVtYWlsIjoiZ2FicmllbC5mZWxpcGUuc29hcmVzQHRhb3Rlc3RpbmcuY29tIn0.Rksf5CATsRQOP8Db4vu_GhakXjhpc0nzVrKkvuuKgxRuzwa5CYQsw6BfO3q7jBvRHTHqzsMhEi00LsTLNHgnNGdtGwI0CRqYa6u8MQI95lbt4nIT3QuR_QY-cCWAP08dhReSbDhMtl3ybndBwrsteE6JP52KJqkgaSkt4QjHLR54NsuvjrCIShG4I855QdRRqqrxRZRA5s9gxq7-tJt_bYJsoLQKflz3cxy_hzeKhqQFcsbpkFrIDhM21FxROsKBEZPdFXhvnZ_pYreiJadUk9CmxeszLdM_tOIz2Ewo3L_X3BkfbpJthUxc3-H8m1yfABo0XbC56lZhdC12DVgLjA
`

![Screenshot 2023-01-09 at 14 26 25](https://user-images.githubusercontent.com/1467589/211318755-910667c6-0bd9-4123-84a6-16037d59fc7b.png)


