### PR TITLE
feat: store and retrieve LTI launch data

### DIFF
--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -150,6 +150,7 @@ class LtiLaunchData implements \JsonSerializable
         LtiMessagePayloadInterface $ltiMessagePayload,
         PlatformInterface $platform = null
     ): self {
+        // phpcs:disable Generic.Files.LineLength
         $variables[self::OAUTH_CONSUMER_KEY] = '';
         $variables[self::RESOURCE_LINK_ID] = $ltiMessagePayload->getResourceLink() ? $ltiMessagePayload->getResourceLink()->getIdentifier() : null;
         $variables[self::RESOURCE_LINK_TITLE] = $ltiMessagePayload->getResourceLink() ? $ltiMessagePayload->getResourceLink()->getTitle() : null;
@@ -176,7 +177,7 @@ class LtiLaunchData implements \JsonSerializable
         $variables[self::LTI_FOR_USER_NAME] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getName() : null;
         $variables[self::LTI_FOR_USER_PERSON_SOURCED_ID] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getPersonSourcedId() : null;
         $variables[self::LTI_FOR_USER_ROLES] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getRoles() : null;
-
+        // phpcs:enable
         if ($platform) {
             // we need to have inner platform ID
             $variables[self::TOOL_CONSUMER_INSTANCE_ID] = $platform->getIdentifier();
@@ -198,11 +199,17 @@ class LtiLaunchData implements \JsonSerializable
 
         // review mode
         if (isset($customParams[self::LTI_SHOW_SCORE])) {
-            $variables[self::LTI_SHOW_SCORE] = filter_var($customParams[self::LTI_SHOW_SCORE], FILTER_VALIDATE_BOOLEAN);
+            $variables[self::LTI_SHOW_SCORE] = filter_var(
+                $customParams[self::LTI_SHOW_SCORE],
+                FILTER_VALIDATE_BOOLEAN
+            );
         }
 
         if (isset($customParams[self::LTI_SHOW_CORRECT])) {
-            $variables[self::LTI_SHOW_CORRECT] = filter_var($customParams[self::LTI_SHOW_CORRECT], FILTER_VALIDATE_BOOLEAN);
+            $variables[self::LTI_SHOW_CORRECT] = filter_var(
+                $customParams[self::LTI_SHOW_CORRECT],
+                FILTER_VALIDATE_BOOLEAN
+            );
         }
 
         return new static($variables, $customParams);

--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -111,7 +111,7 @@ class LtiLaunchData implements \JsonSerializable
 
     public static function fromJsonArray(array $json): LtiLaunchData
     {
-        self::unserializeAgsClaims($json);
+        static::unserializeAgsClaims($json);
         return new static($json['variables'], $json['customParams']);
     }
 

--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -111,9 +111,7 @@ class LtiLaunchData implements \JsonSerializable
 
     public static function fromJsonArray(array $json): LtiLaunchData
     {
-        if (isset($json['variables'][self::AGS_CLAIMS])) {
-            $json['variables'][self::AGS_CLAIMS] = AgsClaim::denormalize($json['variables'][self::AGS_CLAIMS]);
-        }
+        self::unserializeAgsClaims($json);
         return new static($json['variables'], $json['customParams']);
     }
 
@@ -262,6 +260,13 @@ class LtiLaunchData implements \JsonSerializable
         }
 
         return $returnValue;
+    }
+
+    private static function unserializeAgsClaims(array &$json): void
+    {
+        if (isset($json['variables'][self::AGS_CLAIMS])) {
+            $json['variables'][self::AGS_CLAIMS] = AgsClaim::denormalize($json['variables'][self::AGS_CLAIMS]);
+        }
     }
 
     /**

--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -109,11 +109,7 @@ class LtiLaunchData implements \JsonSerializable
         $this->customParams = $customParameters;
     }
 
-    /**
-     * @param array $json
-     * @return LtiLaunchData
-     */
-    public static function fromJsonArray($json)
+    public static function fromJsonArray(array $json): LtiLaunchData
     {
         if (isset($json['variables'][self::AGS_CLAIMS])) {
             $json['variables'][self::AGS_CLAIMS] = AgsClaim::denormalize($json['variables'][self::AGS_CLAIMS]);
@@ -560,9 +556,10 @@ class LtiLaunchData implements \JsonSerializable
     public function jsonSerialize()
     {
         return [
-            'variables' => array_map(function ($var) {
-                return $var instanceof AgsClaim ? $var->normalize() : $var;
-            }, $this->variables),
+            'variables' => array_map(
+                fn($var) => $var instanceof AgsClaim ? $var->normalize() : $var,
+                $this->variables
+            ),
             'customParams' => $this->customParams,
         ];
     }

--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -143,42 +143,63 @@ class LtiLaunchData implements \JsonSerializable
     }
 
     public static function fromLti1p3MessagePayload(
-        LtiMessagePayloadInterface $ltiMessagePayload,
+        LtiMessagePayloadInterface $payload,
         PlatformInterface $platform = null
     ): self {
-        // phpcs:disable Generic.Files.LineLength
         $variables[self::OAUTH_CONSUMER_KEY] = '';
-        $variables[self::RESOURCE_LINK_ID] = $ltiMessagePayload->getResourceLink() ? $ltiMessagePayload->getResourceLink()->getIdentifier() : null;
-        $variables[self::RESOURCE_LINK_TITLE] = $ltiMessagePayload->getResourceLink() ? $ltiMessagePayload->getResourceLink()->getTitle() : null;
-        $variables[self::CONTEXT_ID] = $ltiMessagePayload->getContext() ? $ltiMessagePayload->getContext()->getIdentifier() : null;
-        $variables[self::CONTEXT_LABEL] = $ltiMessagePayload->getContext() ? $ltiMessagePayload->getContext()->getLabel() : null;
-        $variables[self::CONTEXT_TITLE] = $ltiMessagePayload->getContext() ? $ltiMessagePayload->getContext()->getTitle() : null;
-        $variables[self::USER_ID] = $ltiMessagePayload->getUserIdentity() ? $ltiMessagePayload->getUserIdentity()->getIdentifier() : null;
-        $variables[self::ROLES] = implode(',', $ltiMessagePayload->getRoles());
-        $variables[self::LIS_PERSON_NAME_GIVEN] = $ltiMessagePayload->getUserIdentity() ? $ltiMessagePayload->getUserIdentity()->getGivenName() : null;
-        $variables[self::LIS_PERSON_NAME_FAMILY] = $ltiMessagePayload->getUserIdentity() ? $ltiMessagePayload->getUserIdentity()->getFamilyName() : null;
-        $variables[self::LIS_PERSON_NAME_FULL] = $ltiMessagePayload->getUserIdentity() ? $ltiMessagePayload->getUserIdentity()->getName() : null;
-        $variables[self::LIS_PERSON_CONTACT_EMAIL_PRIMARY] = $ltiMessagePayload->getUserIdentity() ? $ltiMessagePayload->getUserIdentity()->getEmail() : null;
-        $variables[self::LAUNCH_PRESENTATION_LOCALE] = $ltiMessagePayload->getLaunchPresentation() ? $ltiMessagePayload->getLaunchPresentation()->getLocale() : null;
-        $variables[self::LAUNCH_PRESENTATION_RETURN_URL] = $ltiMessagePayload->getLaunchPresentation() ? $ltiMessagePayload->getLaunchPresentation()->getReturnUrl() : null;
-        $variables[self::LTI_VERSION] = $ltiMessagePayload->getVersion();
-        $variables[self::LTI_MESSAGE_TYPE] = $ltiMessagePayload->getMessageType();
-        $variables[self::LIS_RESULT_SOURCEDID] = $ltiMessagePayload->getBasicOutcome() ? $ltiMessagePayload->getBasicOutcome()->getLisResultSourcedId() : null;
-        $variables[self::LIS_OUTCOME_SERVICE_URL] = $ltiMessagePayload->getBasicOutcome() ? $ltiMessagePayload->getBasicOutcome()->getLisOutcomeServiceUrl() : null;
+        $variables[self::RESOURCE_LINK_ID] =
+            $payload->getResourceLink() ? $payload->getResourceLink()->getIdentifier() : null;
+        $variables[self::RESOURCE_LINK_TITLE] =
+            $payload->getResourceLink() ? $payload->getResourceLink()->getTitle() : null;
 
-        $variables[self::LTI_FOR_USER_ID] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getIdentifier() : null;
-        $variables[self::LTI_FOR_USER_EMAIL] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getEmail() : null;
-        $variables[self::LTI_FOR_USER_FAMILY_NAME] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getFamilyName() : null;
-        $variables[self::LTI_FOR_USER_GIVEN_NAME] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getGivenName() : null;
-        $variables[self::LTI_FOR_USER_NAME] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getName() : null;
-        $variables[self::LTI_FOR_USER_PERSON_SOURCED_ID] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getPersonSourcedId() : null;
-        $variables[self::LTI_FOR_USER_ROLES] = $ltiMessagePayload->getForUser() ? $ltiMessagePayload->getForUser()->getRoles() : null;
-        // phpcs:enable
+        $variables[self::CONTEXT_ID] = $payload->getContext() ? $payload->getContext()->getIdentifier() : null;
+        $variables[self::CONTEXT_LABEL] = $payload->getContext() ? $payload->getContext()->getLabel() : null;
+        $variables[self::CONTEXT_TITLE] = $payload->getContext() ? $payload->getContext()->getTitle() : null;
+
+        $variables[self::USER_ID] =
+            $payload->getUserIdentity() ? $payload->getUserIdentity()->getIdentifier() : null;
+
+        $variables[self::ROLES] = implode(',', $payload->getRoles());
+        $variables[self::LIS_PERSON_NAME_GIVEN] =
+            $payload->getUserIdentity() ? $payload->getUserIdentity()->getGivenName() : null;
+        $variables[self::LIS_PERSON_NAME_FAMILY] =
+            $payload->getUserIdentity() ? $payload->getUserIdentity()->getFamilyName() : null;
+        $variables[self::LIS_PERSON_NAME_FULL] =
+            $payload->getUserIdentity() ? $payload->getUserIdentity()->getName() : null;
+        $variables[self::LIS_PERSON_CONTACT_EMAIL_PRIMARY] =
+            $payload->getUserIdentity() ? $payload->getUserIdentity()->getEmail() : null;
+
+        $variables[self::LAUNCH_PRESENTATION_LOCALE] =
+            $payload->getLaunchPresentation() ? $payload->getLaunchPresentation()->getLocale() : null;
+        $variables[self::LAUNCH_PRESENTATION_RETURN_URL] =
+            $payload->getLaunchPresentation() ? $payload->getLaunchPresentation()->getReturnUrl() : null;
+
+        $variables[self::LTI_VERSION] = $payload->getVersion();
+        $variables[self::LTI_MESSAGE_TYPE] = $payload->getMessageType();
+        $variables[self::LIS_RESULT_SOURCEDID] =
+            $payload->getBasicOutcome() ? $payload->getBasicOutcome()->getLisResultSourcedId() : null;
+        $variables[self::LIS_OUTCOME_SERVICE_URL] =
+            $payload->getBasicOutcome() ? $payload->getBasicOutcome()->getLisOutcomeServiceUrl() : null;
+        $variables[self::LTI_FOR_USER_ID] =
+            $payload->getForUser() ? $payload->getForUser()->getIdentifier() : null;
+        $variables[self::LTI_FOR_USER_EMAIL] =
+            $payload->getForUser() ? $payload->getForUser()->getEmail() : null;
+        $variables[self::LTI_FOR_USER_FAMILY_NAME] =
+            $payload->getForUser() ? $payload->getForUser()->getFamilyName() : null;
+        $variables[self::LTI_FOR_USER_GIVEN_NAME] =
+            $payload->getForUser() ? $payload->getForUser()->getGivenName() : null;
+        $variables[self::LTI_FOR_USER_NAME] =
+            $payload->getForUser() ? $payload->getForUser()->getName() : null;
+        $variables[self::LTI_FOR_USER_PERSON_SOURCED_ID] =
+            $payload->getForUser() ? $payload->getForUser()->getPersonSourcedId() : null;
+        $variables[self::LTI_FOR_USER_ROLES] =
+            $payload->getForUser() ? $payload->getForUser()->getRoles() : null;
+
         if ($platform) {
             // we need to have inner platform ID
             $variables[self::TOOL_CONSUMER_INSTANCE_ID] = $platform->getIdentifier();
 
-            if ($platformFromClaim = $ltiMessagePayload->getPlatformInstance()) {
+            if ($platformFromClaim = $payload->getPlatformInstance()) {
                 $variables[self::TOOL_CONSUMER_INSTANCE_NAME] = $platformFromClaim->getName();
                 $variables[self::TOOL_CONSUMER_INSTANCE_DESCRIPTION] = $platformFromClaim->getDescription();
             } else {
@@ -187,11 +208,11 @@ class LtiLaunchData implements \JsonSerializable
             }
         }
 
-        if ($ags = $ltiMessagePayload->getAgs()) {
+        if ($ags = $payload->getAgs()) {
             $variables[self::AGS_CLAIMS] = $ags;
         }
 
-        $customParams = $ltiMessagePayload->getCustom();
+        $customParams = $payload->getCustom();
 
         // review mode
         if (isset($customParams[self::LTI_SHOW_SCORE])) {

--- a/test/unit/models/classes/LtiLaunchDataTest.php
+++ b/test/unit/models/classes/LtiLaunchDataTest.php
@@ -29,7 +29,7 @@ use oat\generis\test\MockObject;
 
 class LtiLaunchDataTest extends TestCase
 {
-    const ROOT_URL = 'http://example.com/';
+    private const ROOT_URL = 'http://example.com/';
 
     public function setUp(): void
     {

--- a/test/unit/models/classes/LtiLaunchDataTest.php
+++ b/test/unit/models/classes/LtiLaunchDataTest.php
@@ -38,7 +38,7 @@ class LtiLaunchDataTest extends TestCase
         }
     }
 
-    public function testFromRequest()
+    public function testFromRequest(): void
     {
         $params = ['key1' => 'value2'];
         $extraParams = ['key2' => 'value2'];
@@ -58,17 +58,17 @@ class LtiLaunchDataTest extends TestCase
         $this->assertEquals($extraParams, $subject->getCustomParameters());
     }
 
-    public function testFromJsonArray()
+    public function testFromJsonArray(): void
     {
         $this->jsonSerialisationTest();
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $this->jsonSerialisationTest();
     }
 
-    private function jsonSerialisationTest()
+    private function jsonSerialisationTest(): void
     {
         $agsClaim = new AgsClaim(['scope1', 'scope2'], 'url1', 'url2');
         $subject = new LtiLaunchData([


### PR DESCRIPTION
For feature https://github.com/oat-sa/extension-tao-outcome/pull/232:
- JSON serialization for AGS claims property in order to store LTILaunchData
