### PR TITLE
Guest user lti1p3 lang detection

### DIFF
--- a/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticator.php
+++ b/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticator.php
@@ -69,7 +69,7 @@ class Lti1p3UserAuthenticator extends ConfigurableService implements UserAuthent
 
         $email = $this->getPropertyValue($user, UserRdf::PROPERTY_MAIL);
 
-        $locale = $this->getPropertyValue($user, UserRdf::PROPERTY_DEFLG);
+        $locale = $this->detectLocale($user);
 
         return new UserIdentity($login, trim($fullName), $email, $firstName, $lastName, null, $locale);
     }
@@ -77,6 +77,18 @@ class Lti1p3UserAuthenticator extends ConfigurableService implements UserAuthent
     private function getPropertyValue(User $user, string $propertyName): ?string
     {
         return $user->getPropertyValues($propertyName)[0] ?? null;
+    }
+
+    private function detectLocale(User $user): ?string
+    {
+        if (
+            !empty($this->getPropertyValue($user, UserRdf::PROPERTY_LOGIN))
+            || !defined('DEFAULT_ANONYMOUS_INTERFACE_LANG')
+        ) {
+            return $this->getPropertyValue($user, UserRdf::PROPERTY_DEFLG);
+        } else {
+            return DEFAULT_ANONYMOUS_INTERFACE_LANG;
+        }
     }
 
     private function getUserService(): UserService

--- a/test/unit/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticatorTest.php
+++ b/test/unit/models/classes/Platform/Service/Oidc/Lti1p3UserAuthenticatorTest.php
@@ -106,7 +106,13 @@ class Lti1p3UserAuthenticatorTest extends TestCase
                 new UserIdentity(
                     'userId#123456',
                     '',
-                    ''
+                    '',
+                    null,
+                    null,
+                    null,
+                    defined('DEFAULT_ANONYMOUS_INTERFACE_LANG')
+                        ? DEFAULT_ANONYMOUS_INTERFACE_LANG
+                        : DEFAULT_LANG
                 )
             ),
             $this->subject->authenticate($registration, 'userId#123456')
@@ -132,6 +138,7 @@ class Lti1p3UserAuthenticatorTest extends TestCase
                 [UserRdf::PROPERTY_FIRSTNAME],
                 [UserRdf::PROPERTY_LASTNAME],
                 [UserRdf::PROPERTY_MAIL],
+                [UserRdf::PROPERTY_LOGIN],
                 [UserRdf::PROPERTY_DEFLG]
             )
             ->willReturnOnConsecutiveCalls(
@@ -139,7 +146,8 @@ class Lti1p3UserAuthenticatorTest extends TestCase
                 [$firstName],
                 [$lastName],
                 [$email],
-                [$locale],
+                [$login],
+                [$locale]
             );
 
         $this->userService


### PR DESCRIPTION
# [REL-1101](https://oat-sa.atlassian.net/browse/REL-1101)

## Summary
This PR aim to provide lang detection for guest user and usage of `DEFAULT_ANONYMOUS_INTERFACE_LANG`.

I have some doubts about this solution.  From my point of view, it's a bit crutchy, but at the moment I couldn't find anything more suitable.

## Demo
https://oat-sa.atlassian.net/browse/REL-1101?focusedCommentId=225078

## How to test
- checkout branch
- update `DEFAULT_ANONYMOUS_INTERFACE_LANG`
- launch remote delivery on TAO 3.x
- defined locale should be used in Advance testrunner

[REL-1101]: https://oat-sa.atlassian.net/browse/REL-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ