### PR TITLE
fix: lti provider service configuration change

### DIFF
--- a/models/classes/LtiProvider/LtiProviderService.php
+++ b/models/classes/LtiProvider/LtiProviderService.php
@@ -100,7 +100,10 @@ class LtiProviderService extends ConfigurableService implements LtiProviderRepos
     private function aggregate($result, $method)
     {
         foreach ($this->getOption(self::LTI_PROVIDER_LIST_IMPLEMENTATIONS) as $implementation) {
-            $implementation = $this->buildService($implementation);
+            if (is_array($implementation)) {
+                $implementation = $this->buildService($implementation);
+            }
+            $this->propagate($implementation);
             $result = $method($result, $implementation);
         }
 

--- a/models/classes/LtiProvider/LtiProviderService.php
+++ b/models/classes/LtiProvider/LtiProviderService.php
@@ -100,7 +100,7 @@ class LtiProviderService extends ConfigurableService implements LtiProviderRepos
     private function aggregate($result, $method)
     {
         foreach ($this->getOption(self::LTI_PROVIDER_LIST_IMPLEMENTATIONS) as $implementation) {
-            $this->propagate($implementation);
+            $implementation = $this->buildService($implementation);
             $result = $method($result, $implementation);
         }
 

--- a/test/unit/models/classes/LtiProvider/LtiProviderServiceTest.php
+++ b/test/unit/models/classes/LtiProvider/LtiProviderServiceTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\taoLti\test\unit\models\classes\LtiProvider;
 
 use oat\generis\test\MockObject;
+use oat\generis\test\ServiceManagerMockTrait;
 use oat\generis\test\TestCase;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderRepositoryInterface;
@@ -30,6 +31,8 @@ use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
 
 class LtiProviderServiceTest extends TestCase
 {
+    use ServiceManagerMockTrait;
+
     /** @var LtiProviderService */
     private $subject;
 
@@ -52,6 +55,25 @@ class LtiProviderServiceTest extends TestCase
                 ],
             ]
         );
+    }
+
+    public function testImplementationDefinedAsArray(): void
+    {
+        $serviceManagerMock = $this->getServiceManagerMock();
+        $serviceManagerMock->expects($this->once())
+            ->method('build')->willReturn($this->repository1);
+        $service = new LtiProviderService(
+            [
+                LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
+                    [
+                        'class' => LtiProviderService::class,
+                        'options' => [],
+                    ],
+                ],
+            ]
+        );
+        $service->setServiceManager($serviceManagerMock);
+        $service->count();
     }
     public function testCount(): void
     {


### PR DESCRIPTION
New environment should be configured correctly after first install from seed. This change allows the `LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS` to be defined in a "seed friendly" way.
 
Related to : https://oat-sa.atlassian.net/browse/REL-1164 
  
#### How to test
 
- instead of usual `LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS` setup of for example:
```
return new LtiProviderService([
    LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
        new RdfLtiProviderRepository(),
    ]
]);
```
update to different format without object construction:
```
return new LtiProviderService([
    LtiProviderService::LTI_PROVIDER_LIST_IMPLEMENTATIONS => [
        [
            'class' => 'oat\\taoLti\\models\\classes\\LtiProvider\RdfLtiProviderRepository',
            'options' => [],
        ]
    ]
]);
```
- behavior should remain the same