### PR TITLE
[FIX] [ADF-1075] Do not allow to import classes on LTI Consumer Root Class

### DIFF
--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -28,16 +28,22 @@ use core_kernel_classes_Resource;
 use helpers_Random;
 use InterruptedActionException;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator;
 use oat\taoLti\models\classes\user\UserService;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use tao_actions_Main;
 use tao_models_classes_UserService;
 
 class AuthoringTool extends ToolModule
 {
+    const LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE = 'No matching registration found tool side';
+
     /**
      * @throws LtiException
      * @throws InterruptedActionException
@@ -55,6 +61,9 @@ class AuthoringTool extends ToolModule
         }
     }
 
+    /**
+     * @thorws LtiException
+     */
     protected function getValidatedLtiMessagePayload(): LtiMessagePayloadInterface
     {
         return $this->getServiceLocator()
@@ -64,13 +73,16 @@ class AuthoringTool extends ToolModule
     }
 
     /**
-     * @throws common_exception_Error
      * @throws ActionEnforcingException
      * @throws InterruptedActionException
+     * @throws LtiException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws common_exception_Error
      */
     public function launch(): void
     {
-        $message = $this->getValidatedLtiMessagePayload();
+        $message = $this->getLtiMessageOrRedirectToLogin();
 
         $user = $this->getServiceLocator()
             ->getContainer()
@@ -86,5 +98,53 @@ class AuthoringTool extends ToolModule
             ->startLti1p3Session($message, $user);
 
         $this->forward('run', null, null, $_GET);
+    }
+
+    /**
+     * @return bool
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    private function isFeatureTaoAsToolEnabled(): bool
+    {
+        return $this->getServiceManager()
+            ->getContainer()
+            ->get(FeatureFlagChecker::class)
+            ->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_TAO_AS_A_TOOL);
+    }
+
+    /**
+     * @return LtiMessagePayloadInterface
+     * @throws ContainerExceptionInterface
+     * @throws InterruptedActionException
+     * @throws LtiException
+     * @throws NotFoundExceptionInterface
+     */
+    private function getLtiMessageOrRedirectToLogin(): LtiMessagePayloadInterface
+    {
+        if (!$this->isFeatureTaoAsToolEnabled()) {
+            $this->getLogger()->info(
+                'TAO as tool feature is disabled. The user will be redirected to the login page.'
+            );
+            $this->redirect(_url('login', 'Main', 'tao'));
+        }
+
+        try {
+            $message = $this->getValidatedLtiMessagePayload();
+        } /** @noinspection PhpRedundantCatchClauseInspection */ catch (LtiException $exception) {
+            if ($exception->getMessage() !== self::LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE) {
+                throw $exception;
+            }
+
+            $this->getLogger()->info(
+                sprintf(
+                    'Missing registration for current audience. The user will be redirected to the login page. Exception: %s',
+                    $exception
+                )
+            );
+            $this->redirect(_url('login', 'Main', 'tao'));
+        }
+
+        return $message;
     }
 }

--- a/controller/Import.php
+++ b/controller/Import.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\controller;
+
+use oat\taoLti\models\classes\Importer\RdfImporter;
+use tao_actions_Import;
+use tao_models_classes_import_CsvImporter;
+
+/**
+ * Admin interface for managing LTI 1.3 Platforms entries.
+ *
+ * @package taoLti
+ * @license GPLv2 http://www.opensource.org/licenses/gpl-2.0.php
+ */
+class Import extends tao_actions_Import
+{
+    protected function getAvailableImportHandlers(): array
+    {
+        return [
+            new RdfImporter(),
+            new tao_models_classes_import_CsvImporter()
+        ];
+    }
+}

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -23,7 +23,7 @@
 					<action id="lticonsumer-delete" name="Delete" binding="removeNode" url="/taoLti/ConsumerAdmin/delete" context="instance" group="tree">
                         <icon id="icon-bin"/>
                     </action>
-					<action id="lticonsumer-import" name="Import" url="/tao/Import/index"  context="class" group="tree">
+					<action id="lticonsumer-import" name="Import" url="/taoLti/Import/index"  context="class" group="tree">
                         <icon id="icon-import"/>
                     </action>
 					<action id="lticonsumer-export" name="Export" url="/tao/Export/index"  context="resource" group="tree">

--- a/models/classes/Importer/RdfImporter.php
+++ b/models/classes/Importer/RdfImporter.php
@@ -29,6 +29,7 @@ use Exception;
 use oat\generis\model\OntologyRdf;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\reporting\Report;
+use oat\oatbox\reporting\ReportInterface;
 use oat\taoLti\models\classes\ConsumerService;
 use tao_models_classes_import_RdfImporter;
 use SimpleXMLElement;
@@ -95,16 +96,15 @@ class RdfImporter extends tao_models_classes_import_RdfImporter
 
     /**
      * @param common_report_Report $report
-     * @return common_report_Report|Report
-     * @throws \common_exception_Error
+     * @return common_report_Report
      */
     private function getMainReport(common_report_Report $report): common_report_Report
     {
-        if ($report->contains(Report::TYPE_ERROR) && $report->contains(Report::TYPE_SUCCESS)) {
+        if ($report->contains(ReportInterface::TYPE_ERROR) && $report->contains(ReportInterface::TYPE_SUCCESS)) {
             return Report::createWarning(__("Some resources were not imported"));
         }
 
-        if ($report->contains(Report::TYPE_ERROR)) {
+        if ($report->contains(ReportInterface::TYPE_ERROR)) {
             return Report::createError(__('Failed to import'));
         }
 

--- a/models/classes/Importer/RdfImporter.php
+++ b/models/classes/Importer/RdfImporter.php
@@ -42,7 +42,7 @@ class RdfImporter extends tao_models_classes_import_RdfImporter
     {
         $report = parent::flatImport($this->removeRootClassFromContent($content), $class);
         if ($report->contains(Report::TYPE_ERROR)) {
-            $warningReport = Report::createWarning(__("some imports were not possible"));
+            $warningReport = Report::createWarning(__("Some imports were not possible"));
             $warningReport->add($report);
 
             return $warningReport;

--- a/models/classes/Importer/RdfImporter.php
+++ b/models/classes/Importer/RdfImporter.php
@@ -94,11 +94,7 @@ class RdfImporter extends tao_models_classes_import_RdfImporter
         return (string)$xml->asXML();
     }
 
-    /**
-     * @param common_report_Report $report
-     * @return common_report_Report
-     */
-    private function getMainReport(common_report_Report $report): common_report_Report
+    private function getMainReport(common_report_Report $report): Report
     {
         if ($report->contains(ReportInterface::TYPE_ERROR) && $report->contains(ReportInterface::TYPE_SUCCESS)) {
             return Report::createWarning(__("Some resources were not imported"));
@@ -108,6 +104,6 @@ class RdfImporter extends tao_models_classes_import_RdfImporter
             return Report::createError(__('Failed to import'));
         }
 
-        return $report;
+        return Report::createSuccess(__('Data imported successfully'));
     }
 }

--- a/models/classes/Importer/RdfImporter.php
+++ b/models/classes/Importer/RdfImporter.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Importer;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use Exception;
+use oat\generis\model\OntologyRdf;
+use oat\generis\model\OntologyRdfs;
+use oat\oatbox\reporting\Report;
+use oat\taoLti\models\classes\ConsumerService;
+use tao_models_classes_import_RdfImporter;
+use SimpleXMLElement;
+
+class RdfImporter extends tao_models_classes_import_RdfImporter
+{
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
+    protected function flatImport($content, core_kernel_classes_Class $class)
+    {
+        $report = parent::flatImport($this->removeRootClassFromContent($content), $class);
+        if ($report->contains(Report::TYPE_ERROR)) {
+            $warningReport = Report::createWarning(__("some imports were not possible"));
+            $warningReport->add($report);
+
+            return $warningReport;
+        }
+
+        return $report;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function importProperties(core_kernel_classes_Resource $resource, $propertiesValues, $map, $class)
+    {
+        if (isset($propertiesValues[OntologyRdfs::RDFS_SUBCLASSOF])) {
+            return Report::createError(
+                sprintf(
+                    __('Importing subclasses on this resource is not allowed. Label: %s'),
+                    $this->getLabelFromPropertiesValues($propertiesValues)
+                )
+            );
+        }
+
+        $types = $propertiesValues[OntologyRdf::RDF_TYPE] ?? [];
+        if (count($types) === 1) {
+            $resource->setType($class);
+            unset($propertiesValues[OntologyRdf::RDF_TYPE]);
+        }
+
+        return parent::importProperties($resource, $propertiesValues, $map, $class);
+    }
+
+    private function getLabelFromPropertiesValues(array $propertiesValues): string
+    {
+        $labels = $propertiesValues[OntologyRdfs::RDFS_LABEL] ?? [];
+        $firstLabel = reset($labels);
+
+        return $firstLabel['value'] ?? '';
+    }
+
+    /**
+     * @param string $content
+     * @return string
+     * @throws Exception
+     */
+    private function removeRootClassFromContent(string $content): string
+    {
+        $xml = new SimpleXMLElement($content);
+        $rootClassNodes = $xml->xpath(sprintf('/rdf:RDF/rdf:Description[@rdf:about="%s"]', ConsumerService::CLASS_URI));
+        foreach ($rootClassNodes as $rootClass) {
+            $node = dom_import_simplexml($rootClass);
+            $node->parentNode->removeChild($node);
+        }
+
+        return (string)$xml->asXML();
+    }
+}

--- a/test/unit/models/classes/Importer/RdfImporterTest.php
+++ b/test/unit/models/classes/Importer/RdfImporterTest.php
@@ -159,9 +159,9 @@ CONTENT;
         $flatImportMethod->setAccessible(true);
         $report = $flatImportMethod->invoke($this->sut, $content, $this->resourceClassMock);
 
-        self::assertEquals('warning', $report->getType());
+        self::assertEquals('error', $report->getType());
 
-        self::assertEquals('Some imports were not possible', (string)$report);
+        self::assertEquals('Failed to import', (string)$report);
         self::assertStringContainsString(
             'Importing subclasses on this resource is not allowed. Label: LTI Consumer',
             json_encode($report)
@@ -213,7 +213,7 @@ CONTENT;
 
         self::assertEquals('warning', $report->getType());
 
-        self::assertEquals('Some imports were not possible', (string)$report);
+        self::assertEquals('Some resources were not imported', (string)$report);
         self::assertStringContainsString(
             'Importing subclasses on this resource is not allowed. Label: LTI Consumer',
             json_encode($report)

--- a/test/unit/models/classes/Importer/RdfImporterTest.php
+++ b/test/unit/models/classes/Importer/RdfImporterTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\test\unit\models\classes\Importer;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use core_kernel_persistence_ResourceInterface;
+use core_kernel_persistence_smoothsql_SmoothModel;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\data\RdfsInterface;
+use oat\generis\model\kernel\uri\UriProvider;
+use oat\generis\model\OntologyRdfs;
+use oat\oatbox\event\EventAggregator;
+use oat\oatbox\service\ServiceManager;
+use oat\taoLti\models\classes\Importer\RdfImporter;
+use oat\taoLti\test\unit\OntologyMockTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionException;
+use ReflectionMethod;
+
+class RdfImporterTest extends TestCase
+{
+    use OntologyMockTrait;
+
+    private RdfImporter $sut;
+    private core_kernel_classes_Class|MockObject $resourceClassMock;
+
+    private core_kernel_persistence_ResourceInterface|MockObject $resourceMock;
+    private ServiceManager $currentServiceManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = new RdfImporter();
+
+        $uriProvider = $this->createMock(UriProvider::class);
+        $uriProvider->expects(self::any())
+            ->method('provide')
+            ->willReturn('https://tao.loocal/#123');
+
+        $ontologyMock = $this->buildOntologyMock();
+
+        $this->currentServiceManager = ServiceManager::getServiceManager();
+
+        $serviceManager = $this->getServiceManagerMock([
+            Ontology::SERVICE_ID => $ontologyMock,
+            UriProvider::SERVICE_ID => $uriProvider,
+            EventAggregator::SERVICE_ID => $this->createMock(EventAggregator::class),
+        ]);
+        ServiceManager::setServiceManager($serviceManager);
+
+        $ontologyMock->expects(self::any())
+            ->method('getServiceLocator')
+            ->willReturn($serviceManager);
+
+        $this->resourceClassMock = $this->createMock(core_kernel_classes_Class::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        ServiceManager::setServiceManager($this->currentServiceManager);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testFlatImportSucceeded(): void
+    {
+        /** @noinspection HttpUrlsUsage */
+        $content = <<<'CONTENT'
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.tao.lu/Ontologies/TAO.rdf#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:ns1="c"
+         xmlns:ns2="r">
+
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer">
+    <ns0:UpdatedAt>1696259911.1005</ns0:UpdatedAt>
+    <rdfs:label xml:lang="en-US">LTI Consumer</rdfs:label>
+    <rdfs:subClassOf>http://www.tao.lu/Ontologies/TAO.rdf#OauthConsumer</rdfs:subClassOf>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="https://install.docker.localhost/ontologies/tao.rdf#i651adf8063a0195b2138c3553abfda">
+    <ns1:lassUri>http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer</ns1:lassUri>
+    <ns0:OauthKey>devel</ns0:OauthKey>
+    <ns0:OauthSecret>b651639c2473501be299b461882f1db89484fe4f</ns0:OauthSecret>
+    <ns0:UpdatedAt>1696259968.4526</ns0:UpdatedAt>
+    <rdf:type>http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer</rdf:type>
+    <rdfs:label xml:lang="en-US">consumer</rdfs:label>
+  </rdf:Description>
+</rdf:RDF>
+CONTENT;
+
+        $this->resourceMock->expects(self::once())
+            ->method('setType')
+            ->with(new core_kernel_classes_Resource('https://tao.loocal/#123'), $this->resourceClassMock);
+
+        $flatImportMethod = new ReflectionMethod(RdfImporter::class, 'flatImport');
+        $flatImportMethod->setAccessible(true);
+        $report = $flatImportMethod->invoke($this->sut, $content, $this->resourceClassMock);
+
+        self::assertEquals('success', $report->getType());
+
+        self::assertEquals('Data imported successfully', (string)$report);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testFlatImportFailed(): void
+    {
+        /** @noinspection HttpUrlsUsage */
+        $content = <<<'CONTENT'
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.tao.lu/Ontologies/TAO.rdf#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:ns1="c"
+         xmlns:ns2="r">
+
+  <rdf:Description rdf:about="https://qa-server.eu.premium.lab.taocloud.org/#i64f70d9b1480524078080821f726a7350">
+    <ns0:UpdatedAt>1693912475.4922</ns0:UpdatedAt>
+    <rdfs:label xml:lang="en-US">LTI Consumer</rdfs:label>
+    <rdfs:subClassOf>http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer</rdfs:subClassOf>
+  </rdf:Description>
+</rdf:RDF>
+CONTENT;
+
+        $this->resourceMock->expects(self::never())
+            ->method('setType');
+
+        $flatImportMethod = new ReflectionMethod(RdfImporter::class, 'flatImport');
+        $flatImportMethod->setAccessible(true);
+        $report = $flatImportMethod->invoke($this->sut, $content, $this->resourceClassMock);
+
+        self::assertEquals('warning', $report->getType());
+
+        self::assertEquals('Some imports were not possible', (string)$report);
+        self::assertStringContainsString(
+            'Importing subclasses on this resource is not allowed. Label: LTI Consumer',
+            json_encode($report)
+        );
+        self::assertStringNotContainsString(
+            'Successfully imported',
+            json_encode($report)
+        );
+    }
+
+
+    /**
+     * @throws ReflectionException
+     */
+    public function testFlatImportPartiallyImported(): void
+    {
+        /** @noinspection HttpUrlsUsage */
+        $content = <<<'CONTENT'
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.tao.lu/Ontologies/TAO.rdf#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:ns1="c"
+         xmlns:ns2="r">
+
+  <rdf:Description rdf:about="https://install.docker.localhost/ontologies/tao.rdf#i651adf8063a0195b2138c3553abfda">
+    <ns1:lassUri>http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer</ns1:lassUri>
+    <ns0:OauthKey>devel</ns0:OauthKey>
+    <ns0:OauthSecret>b651639c2473501be299b461882f1db89484fe4f</ns0:OauthSecret>
+    <ns0:UpdatedAt>1696259968.4526</ns0:UpdatedAt>
+    <rdf:type>http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer</rdf:type>
+    <rdfs:label xml:lang="en-US">consumer</rdfs:label>
+  </rdf:Description>
+  
+  <rdf:Description rdf:about="https://qa-server.eu.premium.lab.taocloud.org/#i64f70d9b1480524078080821f726a7350">
+    <ns0:UpdatedAt>1693912475.4922</ns0:UpdatedAt>
+    <rdfs:label xml:lang="en-US">LTI Consumer</rdfs:label>
+    <rdfs:subClassOf>http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer</rdfs:subClassOf>
+  </rdf:Description>
+</rdf:RDF>
+CONTENT;
+
+        $this->resourceMock->expects(self::once())
+            ->method('setType');
+
+        $flatImportMethod = new ReflectionMethod(RdfImporter::class, 'flatImport');
+        $flatImportMethod->setAccessible(true);
+        $report = $flatImportMethod->invoke($this->sut, $content, $this->resourceClassMock);
+
+        self::assertEquals('warning', $report->getType());
+
+        self::assertEquals('Some imports were not possible', (string)$report);
+        self::assertStringContainsString(
+            'Importing subclasses on this resource is not allowed. Label: LTI Consumer',
+            json_encode($report)
+        );
+        self::assertStringContainsString(
+            'Successfully imported',
+            json_encode($report)
+        );
+    }
+
+    private function buildOntologyMock(): MockObject
+    {
+        $ontologyMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothModel::class);
+        $rdfsMock = $this->createMock(RdfsInterface::class);
+        $this->resourceMock = $this->createMock(core_kernel_persistence_ResourceInterface::class);
+
+        $rdfsMock->expects(self::any())
+            ->method('getResourceImplementation')
+            ->willReturn($this->resourceMock);
+        $ontologyMock->expects(self::any())
+            ->method('getRdfsInterface')
+            ->willReturn($rdfsMock);
+        $ontologyMock->expects(self::any())
+            ->method('getProperty')
+            ->with(OntologyRdfs::RDFS_LABEL)
+            ->willReturn(new core_kernel_classes_Property('label'));
+
+        return $ontologyMock;
+    }
+}


### PR DESCRIPTION
This Root class by default does not allow to create classes via interface, but on the import was possible. After this implementation this will not be allowed anymore. Only Resources will be imported. Exception for the root class. If it is present in the rdf, it will be ignored

Refs: https://oat-sa.atlassian.net/browse/ADF-1075

## Demo

https://github.com/oat-sa/extension-tao-lti/assets/11900046/a22966bb-596b-454f-8724-13d0019faaf2


https://github.com/oat-sa/extension-tao-lti/assets/11900046/75e4de5a-7bb0-4ef7-be96-f0b02fa877f4


https://github.com/oat-sa/extension-tao-lti/assets/11900046/d4ca7957-cf2b-442b-8c6a-50ec334bb873

