### PR TITLE
[FIX][SOLAR-387] Add fallback when no registration available or FF TAO_AS_A_TOOL is disabled

### DIFF
--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -42,7 +42,7 @@ use tao_models_classes_UserService;
 
 class AuthoringTool extends ToolModule
 {
-    const LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE = 'No matching registration found tool side';
+    private const LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE = 'No matching registration found tool side';
 
     /**
      * @throws LtiException
@@ -138,7 +138,7 @@ class AuthoringTool extends ToolModule
 
             $this->getLogger()->info(
                 sprintf(
-                    'Missing registration for current audience. The user will be redirected to the login page. Exception: %s',
+                    'Missing registration for current audience. Redirecting to the login page. Exception: %s',
                     $exception
                 )
             );

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -101,7 +101,6 @@ class AuthoringTool extends ToolModule
     }
 
     /**
-     * @return bool
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      */
@@ -114,7 +113,6 @@ class AuthoringTool extends ToolModule
     }
 
     /**
-     * @return LtiMessagePayloadInterface
      * @throws ContainerExceptionInterface
      * @throws InterruptedActionException
      * @throws LtiException

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -131,7 +131,7 @@ class AuthoringTool extends ToolModule
 
         try {
             $message = $this->getValidatedLtiMessagePayload();
-        } /** @noinspection PhpRedundantCatchClauseInspection */ catch (LtiException $exception) {
+        } catch (LtiException $exception) {
             if ($exception->getMessage() !== self::LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE) {
                 throw $exception;
             }

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -136,7 +136,7 @@ class AuthoringTool extends ToolModule
                 throw $exception;
             }
 
-            $this->getLogger()->info(
+            $this->getLogger()->warning(
                 sprintf(
                     'Missing registration for current audience. Redirecting to the login page. Exception: %s',
                     $exception

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -82,20 +82,20 @@ class AuthoringTool extends ToolModule
      */
     public function launch(): void
     {
-        $message = $this->getLtiMessageOrRedirectToLogin();
+        $ltiMessage = $this->getLtiMessageOrRedirectToLogin();
 
         $user = $this->getServiceLocator()
             ->getContainer()
             ->get(tao_models_classes_UserService::class)
             ->addUser(
-                $message->getUserIdentity()->getIdentifier(),
+                $ltiMessage->getUserIdentity()->getIdentifier(),
                 helpers_Random::generateString(UserService::PASSWORD_LENGTH),
-                new core_kernel_classes_Resource(current($message->getRoles()))
+                new core_kernel_classes_Resource(current($ltiMessage->getRoles()))
             );
         $this->getServiceLocator()
             ->getContainer()
             ->get(LtiService::class)
-            ->startLti1p3Session($message, $user);
+            ->startLti1p3Session($ltiMessage, $user);
 
         $this->forward('run', null, null, $_GET);
     }

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -62,7 +62,7 @@ class AuthoringTool extends ToolModule
     }
 
     /**
-     * @thorws LtiException
+     * @throws LtiException
      */
     protected function getValidatedLtiMessagePayload(): LtiMessagePayloadInterface
     {

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -28,16 +28,22 @@ use core_kernel_classes_Resource;
 use helpers_Random;
 use InterruptedActionException;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\LtiService;
 use oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator;
 use oat\taoLti\models\classes\user\UserService;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use tao_actions_Main;
 use tao_models_classes_UserService;
 
 class AuthoringTool extends ToolModule
 {
+    const LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE = 'No matching registration found tool side';
+
     /**
      * @throws LtiException
      * @throws InterruptedActionException
@@ -55,6 +61,9 @@ class AuthoringTool extends ToolModule
         }
     }
 
+    /**
+     * @thorws LtiException
+     */
     protected function getValidatedLtiMessagePayload(): LtiMessagePayloadInterface
     {
         return $this->getServiceLocator()
@@ -64,13 +73,16 @@ class AuthoringTool extends ToolModule
     }
 
     /**
-     * @throws common_exception_Error
      * @throws ActionEnforcingException
      * @throws InterruptedActionException
+     * @throws LtiException
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     * @throws common_exception_Error
      */
     public function launch(): void
     {
-        $message = $this->getValidatedLtiMessagePayload();
+        $message = $this->getLtiMessageOrRedirectToLogin();
 
         $user = $this->getServiceLocator()
             ->getContainer()
@@ -86,5 +98,53 @@ class AuthoringTool extends ToolModule
             ->startLti1p3Session($message, $user);
 
         $this->forward('run', null, null, $_GET);
+    }
+
+    /**
+     * @return bool
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    private function isFeatureTaoAsToolEnabled(): bool
+    {
+        return $this->getServiceManager()
+            ->getContainer()
+            ->get(FeatureFlagChecker::class)
+            ->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_TAO_AS_A_TOOL);
+    }
+
+    /**
+     * @return LtiMessagePayloadInterface
+     * @throws ContainerExceptionInterface
+     * @throws InterruptedActionException
+     * @throws LtiException
+     * @throws NotFoundExceptionInterface
+     */
+    private function getLtiMessageOrRedirectToLogin(): LtiMessagePayloadInterface
+    {
+        if (!$this->isFeatureTaoAsToolEnabled()) {
+            $this->getLogger()->info(
+                'TAO as tool feature is disabled. The user will be redirected to the login page.'
+            );
+            $this->redirect(_url('login', 'Main', 'tao'));
+        }
+
+        try {
+            $message = $this->getValidatedLtiMessagePayload();
+        } /** @noinspection PhpRedundantCatchClauseInspection */ catch (LtiException $exception) {
+            if ($exception->getMessage() !== self::LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE) {
+                throw $exception;
+            }
+
+            $this->getLogger()->info(
+                sprintf(
+                    'Missing registration for current audience. The user will be redirected to the login page. Exception: %s',
+                    $exception
+                )
+            );
+            $this->redirect(_url('login', 'Main', 'tao'));
+        }
+
+        return $message;
     }
 }


### PR DESCRIPTION
We should redirect the user to the default login page in case:

1. The FF is not enabled
2. The LTI Platform config is missing

Please check the [bug ticket](https://oat-sa.atlassian.net/browse/SOLAR-387) for more details.

## Demo
### Current Behavior

https://github.com/oat-sa/extension-tao-lti/assets/11900046/c10f57b0-ea3c-445d-a02b-058a96e034a5


### The fix
https://github.com/oat-sa/extension-tao-lti/assets/11900046/637b7d20-3caa-4179-bbb4-dd232f85b97e
