### PR TITLE
feat: DI container services availability during install

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -19,10 +19,8 @@
  * Copyright (c) 2013-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
-use oat\ltiTestReview\controller\Review;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
-use oat\taoLti\controller\AuthoringTool;
 use oat\taoLti\controller\CookieUtils;
 use oat\taoLti\controller\Security;
 use oat\taoLti\models\classes\LtiRoles;
@@ -30,8 +28,8 @@ use oat\taoLti\models\classes\ServiceProvider\LtiServiceProvider;
 use oat\taoLti\scripts\install\CreateLti1p3RegistrationSnapshotSchema;
 use oat\taoLti\scripts\install\GenerateKeys;
 use oat\taoLti\scripts\install\GenerisSearchWhitelist;
-use oat\taoLti\scripts\install\SetupServices;
 use oat\taoLti\scripts\install\MapLtiSectionVisibility;
+use oat\taoLti\scripts\install\SetupServices;
 use oat\taoLti\scripts\update\Updater;
 
 /**
@@ -54,6 +52,7 @@ return [
         'http://www.imsglobal.org/imspurl/lis/v1/vocab/membership'
      ],
     'install' => [
+        'containerRebuild' => true,
         'rdf' => [
             $extpath . 'install/ontology/lti.rdf',
             $extpath . 'install/ontology/roledefinition.rdf',

--- a/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
@@ -206,7 +206,7 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
     private function toRegistration(array $row): ?Registration
     {
         $toolKeyChain = $this->keyChainRepository
-            ->find($this->platformKeyChainRepositoryLink->getService()->getDefaultKeyId());
+            ->find($this->platformKeyChainRepositoryLink->getDefaultKeyId());
 
         $platform = new Platform(
             $row['statement_id'],

--- a/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
+++ b/models/classes/Platform/Repository/Lti1p3RegistrationSnapshotRepository.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace oat\taoLti\models\classes\Platform\Repository;
 
 use common_persistence_SqlPersistence as SqlPersistence;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\generis\persistence\PersistenceManager;
 use OAT\Library\Lti1p3Core\Platform\Platform;
 use OAT\Library\Lti1p3Core\Registration\Registration;
@@ -32,7 +33,6 @@ use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
 use oat\taoLti\models\classes\Platform\LtiPlatformRegistration;
-use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 use RuntimeException;
 
 class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInterface
@@ -43,8 +43,8 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
     /** @var KeyChainRepositoryInterface */
     private $keyChainRepository;
 
-    /** @var PlatformKeyChainRepository */
-    private $platformKeyChainRepository;
+    /** @var ServiceLink */
+    private $platformKeyChainRepositoryLink;
 
     /** @var DefaultToolConfig */
     private $defaultToolConfig;
@@ -55,13 +55,13 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
     public function __construct(
         PersistenceManager $persistenceManager,
         KeyChainRepositoryInterface $keyChainRepository,
-        PlatformKeyChainRepository $platformKeyChainRepository,
+        ServiceLink $platformKeyChainRepositoryLink,
         DefaultToolConfig $defaultToolConfig,
         string $persistenceId
     ) {
         $this->persistenceManager = $persistenceManager;
         $this->keyChainRepository = $keyChainRepository;
-        $this->platformKeyChainRepository = $platformKeyChainRepository;
+        $this->platformKeyChainRepositoryLink = $platformKeyChainRepositoryLink;
         $this->defaultToolConfig = $defaultToolConfig;
         $this->persistenceId = $persistenceId;
     }
@@ -206,7 +206,7 @@ class Lti1p3RegistrationSnapshotRepository implements RegistrationRepositoryInte
     private function toRegistration(array $row): ?Registration
     {
         $toolKeyChain = $this->keyChainRepository
-            ->find($this->platformKeyChainRepository->getDefaultKeyId());
+            ->find($this->platformKeyChainRepositoryLink->getService()->getDefaultKeyId());
 
         $platform = new Platform(
             $row['statement_id'],

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -28,6 +28,7 @@ use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\generis\model\DependencyInjection\ServiceOptions;
 use oat\generis\persistence\PersistenceManager;
 use OAT\Library\Lti1p3Ags\Factory\Score\ScoreFactory;
@@ -62,10 +63,10 @@ use oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 class LtiServiceProvider implements ContainerServiceProviderInterface
 {
@@ -186,13 +187,21 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             );
 
         $services
+            ->set('PlatformKeyChainRepository.link', ServiceLink::class)
+            ->args(
+                [
+                    PlatformKeyChainRepository::SERVICE_ID
+                ]
+            );
+
+        $services
             ->set(RegistrationRepositoryInterface::class, Lti1p3RegistrationSnapshotRepository::class)
             ->public()
             ->args(
                 [
                     service(PersistenceManager::SERVICE_ID),
                     service(CachedPlatformKeyChainRepository::class),
-                    service(PlatformKeyChainRepository::class),
+                    service('PlatformKeyChainRepository.link'),
                     inline_service(DefaultToolConfig::class)->arg('$baseUri', ROOT_URL),
                     'default'
                 ]

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -187,7 +187,7 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             );
 
         $services
-            ->set('PlatformKeyChainRepository.link', ServiceLink::class)
+            ->set(PlatformKeyChainRepository::SERVICE_ID, ServiceLink::class)
             ->args(
                 [
                     PlatformKeyChainRepository::SERVICE_ID
@@ -201,7 +201,7 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
                 [
                     service(PersistenceManager::SERVICE_ID),
                     service(CachedPlatformKeyChainRepository::class),
-                    service('PlatformKeyChainRepository.link'),
+                    service(PlatformKeyChainRepository::SERVICE_ID),
                     inline_service(DefaultToolConfig::class)->arg('$baseUri', ROOT_URL),
                     'default'
                 ]


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1326

## Goal
DI container services availability during install

## Changelog
- feat: DI container services availability during install
- feat: added the ability to configure the run DI container registered service->method as part extension install process. 

## How to test
Configure extension manifest install section with parameter  ```'containerRebuild' => true,```
Debug one of install->php classes to check the availability of some DI services registered in the provider from ```containerServiceProviders```
Run setup to debug
```docker exec -it studio-phpfpm php tao/scripts/taoSetup.php /var/docker-stack-cli/setup.json -vvv```

To check the ability to run DI container registered service->method configured in the manifest.php file you should add some service to section  [install][php] in this format:
```
            [
                'service' => SomeServiceClass::class,
                'method' => 'methodName',
                'arguments' => ['argument1', ...]
            ]       
```
```containerRebuild``` must be set to true for this extension