### PR TITLE
Feat/ayt 3400/launching authoring by new configurable roles

### DIFF
--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -79,6 +79,7 @@ class AuthoringTool extends ToolModule
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
      * @throws common_exception_Error
+     * @throws WrongLtiRolesException
      */
     public function launch(): void
     {
@@ -92,6 +93,7 @@ class AuthoringTool extends ToolModule
                 helpers_Random::generateString(UserService::PASSWORD_LENGTH),
                 new core_kernel_classes_Resource(current($ltiMessage->getRoles()))
             );
+
         $this->getServiceLocator()
             ->getContainer()
             ->get(LtiService::class)

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -33,6 +33,8 @@ use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\LtiService;
+use oat\taoLti\models\classes\Tool\Exception\WrongLtiRolesException;
+use oat\taoLti\models\classes\Tool\Service\AuthoringLtiRoleService;
 use oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator;
 use oat\taoLti\models\classes\user\UserService;
 use Psr\Container\ContainerExceptionInterface;
@@ -91,7 +93,9 @@ class AuthoringTool extends ToolModule
             ->addUser(
                 $ltiMessage->getUserIdentity()->getIdentifier(),
                 helpers_Random::generateString(UserService::PASSWORD_LENGTH),
-                new core_kernel_classes_Resource(current($ltiMessage->getRoles()))
+                new core_kernel_classes_Resource(
+                    $this->getAuthoringRoleService()->getValidRole($ltiMessage->getRoles())
+                )
             );
 
         $this->getServiceLocator()
@@ -146,5 +150,10 @@ class AuthoringTool extends ToolModule
         }
 
         return $message;
+    }
+
+    private function getAuthoringRoleService(): AuthoringLtiRoleService
+    {
+        return $this->getPsrContainer()->get(AuthoringLtiRoleService::class);
     }
 }

--- a/install/ontology/ltiroles_membership.rdf
+++ b/install/ontology/ltiroles_membership.rdf
@@ -191,7 +191,7 @@
       <rdfs:label xml:lang="en-US"><![CDATA[LTI 1p3 Instructor]]></rdfs:label>
       <rdfs:comment xml:lang="en-US"><![CDATA[The LTI 1p3 Context Instructor Role]]></rdfs:comment>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiBaseRole"/>
-      <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole"/>
+      <generis:includesRole rdf:resource="http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper"/>
       <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#ExternalInstructor">

--- a/install/ontology/ltiroles_person.rdf
+++ b/install/ontology/ltiroles_person.rdf
@@ -43,4 +43,13 @@
     <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   </rdf:Description>
 
+  <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[LTI Institution Administrator (System)]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[The LTI Institution Administrator Role]]></rdfs:comment>
+    <taolti:RoleURN><![CDATA[urn:lti:sysrole:ims/lis/Administrator]]></taolti:RoleURN>
+    <generis:includesRole rdf:resource="http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Developer"/>
+    <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
+  </rdf:Description>
+
  </rdf:RDF>

--- a/migrations/Version202312051317263774_taoLti.php
+++ b/migrations/Version202312051317263774_taoLti.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use core_kernel_classes_Resource;
+use core_kernel_users_Cache;
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\model\user\TaoRoles;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoLti\models\classes\LtiRoles;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202312051317263774_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Apply new http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor and http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator permission for AuthoringTool';
+    }
+
+    public function up(Schema $schema): void
+    {
+        AclProxy::applyRule($this->getLaunchActionRule());
+        AclProxy::applyRule($this->getRunActionRule(LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR));
+        AclProxy::applyRule($this->getRunActionRule(LtiRoles::CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR));
+
+        $this->addReport(
+            Report::createInfo(
+                sprintf(
+                    'Clearing the Generis cache for roles %s',
+                    LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR,
+                )
+            )
+        );
+        core_kernel_users_Cache::removeIncludedRoles(
+            new core_kernel_classes_Resource(LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR)
+        );
+        core_kernel_users_Cache::removeIncludedRoles(
+            new core_kernel_classes_Resource(LtiRoles::CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR)
+        );
+
+        OntologyUpdater::syncModels();
+
+        $this->addReport(Report::createInfo('Apply new permission for AuthoringTool'));
+    }
+
+    public function down(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getLaunchActionRule());
+        AclProxy::revokeRule($this->getRunActionRule(LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR));
+        AclProxy::revokeRule($this->getRunActionRule(LtiRoles::CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR));
+
+        $this->addReport(Report::createInfo('Revoke CONTEXT_INSTRUCTOR, CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR permission for AuthoringTool'));
+    }
+
+    private function getLaunchActionRule(): AccessRule
+    {
+        return new AccessRule(
+            AccessRule::GRANT,
+            TaoRoles::ANONYMOUS,
+            ['ext' => 'taoLti', 'mod' => 'AuthoringTool', 'act' => 'launch']
+        );
+    }
+
+    private function getRunActionRule(string $role): AccessRule
+    {
+        return new AccessRule(
+            AccessRule::GRANT,
+            $role,
+            ['ext' => 'taoLti', 'mod' => 'AuthoringTool', 'act' => 'run']
+        );
+    }
+}

--- a/models/classes/LtiLaunchData.php
+++ b/models/classes/LtiLaunchData.php
@@ -579,7 +579,7 @@ class LtiLaunchData implements \JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'variables' => array_map(

--- a/models/classes/LtiRoles.php
+++ b/models/classes/LtiRoles.php
@@ -110,4 +110,6 @@ interface LtiRoles
     public const CONTEXT_LTI1P3_ADMINISTRATOR_SUB_EXTERNAL_SYSTEM_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSystemAdministrator';
     public const CONTEXT_LTI1P3_ADMINISTRATOR_SUB_SUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support';
     public const CONTEXT_LTI1P3_ADMINISTRATOR_SUB_SYSTEM_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#SystemAdministrator';
+
+    public const CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator';
 }

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -50,6 +50,7 @@ use oat\oatbox\log\LoggerService;
 use oat\taoLti\models\classes\Client\LtiClientFactory;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsScoreService;
 use oat\taoLti\models\classes\LtiAgs\LtiAgsScoreServiceInterface;
+use oat\taoLti\models\classes\LtiRoles;
 use oat\taoLti\models\classes\Platform\Repository\DefaultToolConfig;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationRepository;
 use oat\taoLti\models\classes\Platform\Repository\Lti1p3RegistrationSnapshotRepository;
@@ -57,6 +58,7 @@ use oat\taoLti\models\classes\Platform\Repository\LtiPlatformFactory;
 use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\CachedPlatformKeyChainRepository;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use oat\taoLti\models\classes\Tool\Service\AuthoringLtiRoleService;
 use oat\taoLti\models\classes\Tool\Validation\AuthoringToolValidator;
 use oat\taoLti\models\classes\Tool\Validation\Lti1p3Validator;
 use Psr\Cache\CacheItemPoolInterface;
@@ -77,6 +79,16 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
         $parameters->set(
             'defaultScope',
             $_ENV['LTI_DEFAULT_SCOPE'] ?? 'https://purl.imsglobal.org/spec/lti-bo/scope/basicoutcome'
+        );
+
+        $parameters->set(
+            'rolesAllowed',
+            [
+                LtiRoles::CONTEXT_LTI1P3_ADMINISTRATOR_SUB_DEVELOPER,
+                LtiRoles::CONTEXT_LTI1P3_CONTENT_DEVELOPER_SUB_CONTENT_DEVELOPER,
+                LTIRoles::CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR,
+                LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR
+            ]
         );
 
         $services
@@ -236,6 +248,15 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
                     service(RegistrationRepositoryInterface::class),
                     service(ItemPoolSimpleCacheAdapter::class),
                     service(AuthoringToolValidator::class),
+                ]
+            );
+
+        $services
+            ->set(AuthoringLtiRoleService::class, AuthoringLtiRoleService::class)
+            ->public()
+            ->args(
+                [
+                    param('rolesAllowed')
                 ]
             );
     }

--- a/models/classes/Tool/Exception/WrongLtiRolesException.php
+++ b/models/classes/Tool/Exception/WrongLtiRolesException.php
@@ -20,27 +20,15 @@
 
 declare(strict_types=1);
 
-namespace oat\taoLti\models\classes\Tool\Service;
+namespace oat\taoLti\models\classes\Tool\Exception;
 
-use oat\taoLti\models\classes\Tool\Exception\WrongLtiRolesException;
+use Exception;
+use Throwable;
 
-class AuthoringLtiRoleService
+class WrongLtiRolesException extends Exception
 {
-    public function __construct(array $roleAllowed)
+    public function __construct(string $message = "Role not allowed", int $code = 0, ?Throwable $previous = null)
     {
-        $this->roleAllowed = $roleAllowed;
-    }
-
-    /**
-     * @throws WrongLtiRolesException
-     */
-    public function getValidRole(array $roles): string
-    {
-        $commonRoles = array_intersect($roles, $this->roleAllowed);
-
-        if (empty($commonRoles)) {
-            throw new WrongLtiRolesException();
-        }
-        return current($commonRoles);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/models/classes/Tool/Service/AuthoringLtiRoleService.php
+++ b/models/classes/Tool/Service/AuthoringLtiRoleService.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\Tool\Service;
+
+class AuthoringLtiRoleService
+{
+    public function __construct(array $roleAllowed)
+    {
+        $this->roleAllowed = $roleAllowed;
+    }
+
+    public function getValidRole(array $roles): string
+    {
+        return current(array_intersect($roles, $this->roleAllowed));
+    }
+}

--- a/models/classes/user/LtiUser.php
+++ b/models/classes/user/LtiUser.php
@@ -216,7 +216,7 @@ class LtiUser extends \common_user_User implements ServiceLocatorAwareInterface,
         // nothing to do
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             self::USER_IDENTIFIER => $this->userUri,

--- a/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
+++ b/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\test\unit\models\classes\Tool\Service;
+
+use oat\taoLti\models\classes\LtiRoles;
+use oat\taoLti\models\classes\Tool\Exception\WrongLtiRolesException;
+use oat\taoLti\models\classes\Tool\Service\AuthoringLtiRoleService;
+use PHPUnit\Framework\TestCase;
+
+class AuthoringLtiRoleServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->subject = new AuthoringLtiRoleService(
+            [
+                LtiRoles::CONTEXT_LTI1P3_ADMINISTRATOR_SUB_DEVELOPER,
+                LtiRoles::CONTEXT_LTI1P3_CONTENT_DEVELOPER_SUB_CONTENT_DEVELOPER,
+                LTIRoles::CONTEXT_INSTITUTION_LTI1P3_ADMINISTRATOR,
+                LtiRoles::CONTEXT_LTI1P3_INSTRUCTOR
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider ltiMessageRolesProvider
+     */
+    public function testValidRole(array $rolesProvided, string $expected): void
+    {
+        self::assertEquals($expected, $this->subject->getValidRole($rolesProvided));
+    }
+
+    /**
+     * @dataProvider invalidRolesProvider
+     * @throws WrongLtiRolesException
+     */
+    public function testExpectException(array $roles): void
+    {
+        $this->expectException(WrongLtiRolesException::class);
+        $this->subject->getValidRole($roles);
+    }
+
+    private function invalidRolesProvider(): array
+    {
+        return [
+            'Empty array' => [
+                'roles' => [],
+            ],
+            'UnsupportedRole' => [
+                'roles' => ['http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support']
+            ]
+        ];
+    }
+
+    private
+    function ltiMessageRolesProvider(): array
+    {
+        return [
+            'When one valid roles' => [
+                'rolesProvided' => [
+                    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
+                    'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support'
+                ],
+                'expected' => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator'
+            ],
+            'When more then one valid roles' => [
+                'rolesProvided' => [
+                    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
+                    'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support',
+                    'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper'
+                ],
+                'expected' => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator'
+            ]
+        ];
+    }
+}

--- a/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
+++ b/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
@@ -59,7 +59,7 @@ class AuthoringLtiRoleServiceTest extends TestCase
         $this->subject->getValidRole($roles);
     }
 
-    private function invalidRolesProvider(): array
+    protected function invalidRolesProvider(): array
     {
         return [
             'Empty array' => [
@@ -71,7 +71,7 @@ class AuthoringLtiRoleServiceTest extends TestCase
         ];
     }
 
-    private function ltiMessageRolesProvider(): array
+    protected function ltiMessageRolesProvider(): array
     {
         return [
             'When one valid roles' => [

--- a/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
+++ b/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
@@ -71,8 +71,7 @@ class AuthoringLtiRoleServiceTest extends TestCase
         ];
     }
 
-    private
-    function ltiMessageRolesProvider(): array
+    private function ltiMessageRolesProvider(): array
     {
         return [
             'When one valid roles' => [

--- a/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
+++ b/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
 
 class AuthoringLtiRoleServiceTest extends TestCase
 {
-    protected function setUp(): void
+    public function setUp(): void
     {
         $this->subject = new AuthoringLtiRoleService(
             [
@@ -59,7 +59,7 @@ class AuthoringLtiRoleServiceTest extends TestCase
         $this->subject->getValidRole($roles);
     }
 
-    protected function invalidRolesProvider(): array
+    public function invalidRolesProvider(): array
     {
         return [
             'Empty array' => [
@@ -71,7 +71,7 @@ class AuthoringLtiRoleServiceTest extends TestCase
         ];
     }
 
-    protected function ltiMessageRolesProvider(): array
+    public function ltiMessageRolesProvider(): array
     {
         return [
             'When one valid roles' => [

--- a/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
+++ b/test/unit/models/classes/Tool/Service/AuthoringLtiRoleServiceTest.php
@@ -81,7 +81,7 @@ class AuthoringLtiRoleServiceTest extends TestCase
                 ],
                 'expected' => 'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator'
             ],
-            'When more then one valid roles' => [
+            'When more than one valid roles' => [
                 'rolesProvided' => [
                     'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator',
                     'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support',


### PR DESCRIPTION
How to reproduce:

Launch authoring tool using `devkit` [link](https://devkit.docker.localhost/platform/message/launch/lti-resource-link?registration=devkit__backoffice&user_type=list&user_list=r2d2&launch_url=http://backoffice.docker.localhost/taoLti/AuthoringTool/launch&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper%23ContentDeveloper%22,%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator%23Developer%22%0D%0A%20%20%20%20%5D%0D%0A%7D)

Launch without allowed roles: 
- `http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor`
- `http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator`
- `http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper`
-  `http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Developer`


https://github.com/oat-sa/extension-tao-lti/assets/16231681/0208fe07-0214-4eb6-9fc6-52627d7a4a0f


