### PR TITLE
feat: publish to two solar tenants

### DIFF
--- a/config/default/PlatformKeyChainRepository.conf.php
+++ b/config/default/PlatformKeyChainRepository.conf.php
@@ -2,11 +2,11 @@
 
 use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 
-return new PlatformKeyChainRepository(
+return new PlatformKeyChainRepository([
     [
         PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => 'defaultPlatformKeyId',
         PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME => 'defaultPlatformKeyName',
         PlatformKeyChainRepository::OPTION_DEFAULT_PUBLIC_KEY_PATH => '/platform/default/public.key',
         PlatformKeyChainRepository::OPTION_DEFAULT_PRIVATE_KEY_PATH => '/platform/default/private.key',
     ]
-);
+]);

--- a/migrations/Version202402271423013774_taoLti.php
+++ b/migrations/Version202402271423013774_taoLti.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\security\xsrf\TokenService;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+
+final class Version202402271423013774_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update PlatformKeyChain config format';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $platformKeyChainRepository = $this->getServiceLocator()->get(PlatformKeyChainRepository::SERVICE_ID);
+        $options = $platformKeyChainRepository->getOptions();
+        $platformKeyChainRepository->setOptions([$options]);
+        $this->getServiceLocator()->register(PlatformKeyChainRepository::SERVICE_ID, $platformKeyChainRepository);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platformKeyChainRepository = $this->getServiceLocator()->get(PlatformKeyChainRepository::SERVICE_ID);
+        $options = $platformKeyChainRepository->getOptions();
+        $platformKeyChainRepository->setOptions(reset($options));
+        $this->getServiceLocator()->register(PlatformKeyChainRepository::SERVICE_ID, $platformKeyChainRepository);
+    }
+}

--- a/models/classes/Exception/PlatformKeyChainException.php
+++ b/models/classes/Exception/PlatformKeyChainException.php
@@ -15,18 +15,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
  */
 
-declare(strict_types=1);
+namespace oat\taoLti\models\classes\Exception;
 
-namespace oat\taoLti\models\classes\Platform\Service;
+use oat\taoLti\models\classes\LtiException;
 
-use OAT\Library\Lti1p3Core\Security\Key\KeyChainInterface;
-
-interface KeyChainGeneratorInterface
+class PlatformKeyChainException extends LtiException
 {
-    public const OPTION_DATA_STORE = 'sslConfig';
-
-    public function generate(string $id, string $name, ?string $passPhrase): KeyChainInterface;
 }

--- a/models/classes/Platform/Service/CachedKeyChainGenerator.php
+++ b/models/classes/Platform/Service/CachedKeyChainGenerator.php
@@ -32,7 +32,6 @@ use Psr\SimpleCache\CacheInterface;
 
 class CachedKeyChainGenerator extends ConfigurableService implements KeyChainGeneratorInterface
 {
-
     public function generate(
         string $id = PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID_VALUE,
         string $name = PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME_VALUE,

--- a/models/classes/Platform/Service/OpenSslKeyChainGenerator.php
+++ b/models/classes/Platform/Service/OpenSslKeyChainGenerator.php
@@ -30,17 +30,20 @@ use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRep
 
 class OpenSslKeyChainGenerator extends ConfigurableService implements KeyChainGeneratorInterface
 {
-    public function generate(): KeyChainInterface
-    {
+    public function generate(
+        string $id = PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID,
+        string $name = PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME,
+        ?string $passPhrase = null
+    ): KeyChainInterface {
         $resource = openssl_pkey_new($this->getOption(self::OPTION_DATA_STORE));
-        openssl_pkey_export($resource, $privateKey);
+        openssl_pkey_export($resource, $privateKey, $passPhrase);
         $publicKey = openssl_pkey_get_details($resource);
 
         return new KeyChain(
-            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID,
-            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME,
+            $id,
+            $name,
             new Key($publicKey['key']),
-            new Key($privateKey)
+            new Key($privateKey, $passPhrase)
         );
     }
 }

--- a/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepository.php
@@ -46,20 +46,19 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
      * @throws InvalidArgumentException
      * @throws ErrorException
      */
-    public function save(KeyChainInterface $keyChain): void
+    public function saveDefaultKeyChain(KeyChainInterface $keyChain): void
     {
         $this->setKeys(
             $keyChain,
             $keyChain->getIdentifier()
         );
 
-        $this->getPlatformKeyChainRepository()->save($keyChain);
+        $this->getPlatformKeyChainRepository()->saveDefaultKeyChain($keyChain);
     }
 
     public function find(string $identifier): ?KeyChainInterface
     {
         if ($this->exists($identifier)) {
-            //TODO: Needs to be refactor if we have multiple key chains
             $rawKeys = $this->getCacheService()->getMultiple(
                 [
                     sprintf(self::PRIVATE_PATTERN, $identifier),
@@ -93,7 +92,6 @@ class CachedPlatformKeyChainRepository extends ConfigurableService implements Ke
         }
 
         if ($this->exists($query->getIdentifier())) {
-            //TODO: Needs to be refactor if we have multiple key chains
             $rawKeys = $this->getCacheService()->getMultiple(
                 [
                     sprintf(self::PRIVATE_PATTERN, $query->getIdentifier()),

--- a/models/classes/Security/DataAccess/Repository/PlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/PlatformKeyChainRepository.php
@@ -69,8 +69,8 @@ class PlatformKeyChainRepository extends ConfigurableService implements KeyChain
 
         $publicKeyPath = $configs[self::OPTION_DEFAULT_PUBLIC_KEY_PATH] ?? null;
         $privateKeyPath = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PATH] ?? null;
-        $isPublicKeySaved = null;
-        $isPrivateKeySaved = null;
+        $isPublicKeySaved = false;
+        $isPrivateKeySaved = false;
 
         if ($publicKeyPath !== null && $privateKeyPath !== null) {
             $isPublicKeySaved = $this->getFileSystem()
@@ -105,9 +105,10 @@ class PlatformKeyChainRepository extends ConfigurableService implements KeyChain
             return null;
         }
 
+        $keyName = $configs[self::OPTION_DEFAULT_KEY_NAME] ?? '';
         $publicKeyPath = $configs[self::OPTION_DEFAULT_PUBLIC_KEY_PATH] ?? null;
         $privateKeyPath = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PATH] ?? null;
-        $privateKeyPassword = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] ?? null;
+        $privateKeyPassphrase = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] ?? null;
 
         if (!$publicKeyPath || !$privateKeyPath) {
             throw new PlatformKeyChainException('The key path is not defined');
@@ -121,10 +122,10 @@ class PlatformKeyChainRepository extends ConfigurableService implements KeyChain
         }
 
         return new KeyChain(
-            $configs[self::OPTION_DEFAULT_KEY_ID] ?? null,
-            $configs[self::OPTION_DEFAULT_KEY_NAME] ?? null,
+            $identifier,
+            $keyName,
             new Key($publicKey),
-            new Key($privateKey, $privateKeyPassword)
+            new Key($privateKey, $privateKeyPassphrase)
         );
     }
 
@@ -133,10 +134,10 @@ class PlatformKeyChainRepository extends ConfigurableService implements KeyChain
         $options = $this->getOptions();
         foreach ($options as $configs) {
             $defaultKeyId = $configs[self::OPTION_DEFAULT_KEY_ID] ?? null;
-            $defaultKeyName = $configs[self::OPTION_DEFAULT_KEY_NAME] ?? null;
+            $defaultKeyName = $configs[self::OPTION_DEFAULT_KEY_NAME] ?? '';
             $publicKeyPath = $configs[self::OPTION_DEFAULT_PUBLIC_KEY_PATH] ?? null;
             $privateKeyPath = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PATH] ?? null;
-            $privateKeyPassword = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] ?? null;
+            $privateKeyPassphrase = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] ?? null;
 
             if ($defaultKeyId && $publicKeyPath && $privateKeyPath) {
                 $publicKey = $this->getFileSystem()->read($publicKeyPath);
@@ -146,7 +147,7 @@ class PlatformKeyChainRepository extends ConfigurableService implements KeyChain
                     $defaultKeyId,
                     $defaultKeyName,
                     new TaoKey($publicKey),
-                    new TaoKey($privateKey, $privateKeyPassword)
+                    new TaoKey($privateKey, $privateKeyPassphrase)
                 );
             }
         }

--- a/models/classes/Security/DataAccess/Repository/PlatformKeyChainRepository.php
+++ b/models/classes/Security/DataAccess/Repository/PlatformKeyChainRepository.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace oat\taoLti\models\classes\Security\DataAccess\Repository;
 
 use common_exception_NoImplementation;
-use ErrorException;
 use League\Flysystem\FilesystemInterface;
 use OAT\Library\Lti1p3Core\Security\Key\Key;
 use OAT\Library\Lti1p3Core\Security\Key\KeyChain;
@@ -31,94 +30,132 @@ use OAT\Library\Lti1p3Core\Security\Key\KeyChainInterface;
 use OAT\Library\Lti1p3Core\Security\Key\KeyChainRepositoryInterface;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\model\security\Business\Domain\Key\KeyChainCollection;
-use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
 use oat\tao\model\security\Business\Domain\Key\Key as TaoKey;
 use oat\tao\model\security\Business\Domain\Key\KeyChain as TaoKeyChain;
+use oat\tao\model\security\Business\Domain\Key\KeyChainCollection;
+use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
+use oat\taoLti\models\classes\Exception\PlatformKeyChainException;
 
 class PlatformKeyChainRepository extends ConfigurableService implements KeyChainRepositoryInterface
 {
     public const SERVICE_ID = 'taoLti/PlatformKeyChainRepository';
     public const OPTION_DEFAULT_KEY_ID = 'defaultKeyId';
+    public const OPTION_DEFAULT_KEY_ID_VALUE = 'defaultPlatformKeyId';
     public const OPTION_DEFAULT_KEY_NAME = 'defaultKeyName';
+    public const OPTION_DEFAULT_KEY_NAME_VALUE = 'defaultPlatformKeyName';
     public const OPTION_DEFAULT_PUBLIC_KEY_PATH = 'defaultPublicKeyPath';
     public const OPTION_DEFAULT_PRIVATE_KEY_PATH = 'defaultPrivateKeyPath';
+    public const OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE = 'defaultPrivateKeyPassphrase';
     public const FILE_SYSTEM_ID = 'ltiKeyChain';
 
-    /**
-     * @throws ErrorException
-     */
-    public function save(KeyChainInterface $keyChain): void
-    {
-        $isPublicKeySaved = $this->getFileSystem()
-            ->put(
-                ltrim($this->getOption(self::OPTION_DEFAULT_PUBLIC_KEY_PATH), DIRECTORY_SEPARATOR),
-                $keyChain->getPublicKey()->getContent()
-            );
 
-        $isPrivateKeySaved = $this->getFileSystem()
-            ->put(
-                ltrim($this->getOption(self::OPTION_DEFAULT_PRIVATE_KEY_PATH), DIRECTORY_SEPARATOR),
-                $keyChain->getPrivateKey()->getContent()
-            );
+    public function saveDefaultKeyChain(KeyChainInterface $keyChain): void
+    {
+        $this->save($keyChain, $this->getDefaultKeyId());
+    }
+
+    public function saveKeyChain(KeyChainInterface $keyChain): void
+    {
+        $this->save($keyChain, $keyChain->getIdentifier());
+    }
+
+    protected function save(KeyChainInterface $keyChain, string $identifier): void
+    {
+        $configs = $this->findConfiguration($identifier);
+
+        if (empty($configs)) {
+            throw new PlatformKeyChainException('Impossible to write LTI keys. Configuration not found');
+        }
+
+        $publicKeyPath = $configs[self::OPTION_DEFAULT_PUBLIC_KEY_PATH] ?? null;
+        $privateKeyPath = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PATH] ?? null;
+        $isPublicKeySaved = null;
+        $isPrivateKeySaved = null;
+
+        if ($publicKeyPath !== null && $privateKeyPath !== null) {
+            $isPublicKeySaved = $this->getFileSystem()
+                ->put(
+                    ltrim($publicKeyPath, DIRECTORY_SEPARATOR),
+                    $keyChain->getPublicKey()->getContent()
+                );
+
+            $isPrivateKeySaved = $this->getFileSystem()
+                ->put(
+                    ltrim($privateKeyPath, DIRECTORY_SEPARATOR),
+                    $keyChain->getPrivateKey()->getContent()
+                );
+        }
 
         if (!$isPublicKeySaved || !$isPrivateKeySaved) {
-            throw new ErrorException('Impossible to write LTI keys');
+            throw new PlatformKeyChainException('Impossible to write LTI keys');
         }
     }
 
     public function getDefaultKeyId(): string
     {
-        return $this->getOption(PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID, '');
+        $options = $this->getOptions();
+        return reset($options)[self::OPTION_DEFAULT_KEY_ID] ?? '';
     }
 
-    /**
-     * @throws common_exception_NoImplementation
-     */
     public function find(string $identifier): ?KeyChainInterface
     {
-        if ($identifier !== $this->getDefaultKeyId()) {
+        $configs = $this->findConfiguration($identifier);
+
+        if (empty($configs)) {
             return null;
         }
 
-        $publicKey = $this->getFileSystem()
-            ->read($this->getOption(self::OPTION_DEFAULT_PUBLIC_KEY_PATH));
+        $publicKeyPath = $configs[self::OPTION_DEFAULT_PUBLIC_KEY_PATH] ?? null;
+        $privateKeyPath = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PATH] ?? null;
+        $privateKeyPassword = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] ?? null;
 
-        $privateKey = $this->getFileSystem()
-            ->read($this->getOption(self::OPTION_DEFAULT_PRIVATE_KEY_PATH));
+        if (!$publicKeyPath || !$privateKeyPath) {
+            throw new PlatformKeyChainException('The key path is not defined');
+        }
+
+        $publicKey = $this->getFileSystem()->read($publicKeyPath);
+        $privateKey = $this->getFileSystem()->read($privateKeyPath);
 
         if ($publicKey === false || $privateKey === false) {
-            throw new ErrorException('Impossible to read LTI keys');
+            throw new PlatformKeyChainException('Impossible to read LTI keys');
         }
 
         return new KeyChain(
-            $this->getDefaultKeyId(),
-            $this->getOption(self::OPTION_DEFAULT_KEY_NAME),
+            $configs[self::OPTION_DEFAULT_KEY_ID] ?? null,
+            $configs[self::OPTION_DEFAULT_KEY_NAME] ?? null,
             new Key($publicKey),
-            new Key($privateKey)
+            new Key($privateKey, $privateKeyPassword)
         );
     }
 
     public function findAll(KeyChainQuery $query): KeyChainCollection
     {
-        $publicKey = $this->getFileSystem()
-            ->read($this->getOption(self::OPTION_DEFAULT_PUBLIC_KEY_PATH));
+        $options = $this->getOptions();
+        foreach ($options as $configs) {
+            $defaultKeyId = $configs[self::OPTION_DEFAULT_KEY_ID] ?? null;
+            $defaultKeyName = $configs[self::OPTION_DEFAULT_KEY_NAME] ?? null;
+            $publicKeyPath = $configs[self::OPTION_DEFAULT_PUBLIC_KEY_PATH] ?? null;
+            $privateKeyPath = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PATH] ?? null;
+            $privateKeyPassword = $configs[self::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] ?? null;
 
-        $privateKey = $this->getFileSystem()
-            ->read($this->getOption(self::OPTION_DEFAULT_PRIVATE_KEY_PATH));
+            if ($defaultKeyId && $publicKeyPath && $privateKeyPath) {
+                $publicKey = $this->getFileSystem()->read($publicKeyPath);
+                $privateKey = $this->getFileSystem()->read($privateKeyPath);
 
-        if ($publicKey === false || $privateKey === false) {
-            throw new ErrorException('Impossible to read LTI keys');
+                $keyChains[] = new TaoKeyChain(
+                    $defaultKeyId,
+                    $defaultKeyName,
+                    new TaoKey($publicKey),
+                    new TaoKey($privateKey, $privateKeyPassword)
+                );
+            }
         }
 
-        $keyChain = new TaoKeyChain(
-            $this->getOption(self::OPTION_DEFAULT_KEY_ID),
-            $this->getOption(self::OPTION_DEFAULT_KEY_NAME),
-            new TaoKey($publicKey),
-            new TaoKey($privateKey)
-        );
+        if (empty($keyChains)) {
+            throw new PlatformKeyChainException('Impossible to read LTI keys');
+        }
 
-        return new KeyChainCollection($keyChain);
+        return new KeyChainCollection(...$keyChains);
     }
 
 
@@ -137,5 +174,21 @@ class PlatformKeyChainRepository extends ConfigurableService implements KeyChain
             ->get(FileSystemService::SERVICE_ID);
 
         return $fileSystemService->getFileSystem(self::FILE_SYSTEM_ID);
+    }
+
+    /**
+     * @param string $identifier
+     * @return array|null
+     */
+    protected function findConfiguration(string $identifier): ?array
+    {
+        $options = $this->getOptions();
+        foreach ($options as $configs) {
+            if ($configs[self::OPTION_DEFAULT_KEY_ID] === $identifier) {
+                return $configs;
+            }
+        }
+
+        return null;
     }
 }

--- a/scripts/tools/GenerateKeys.php
+++ b/scripts/tools/GenerateKeys.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\scripts\tools;
+
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+use oat\taoLti\models\classes\Platform\Service\OpenSslKeyChainGenerator;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
+use oat\taoLti\models\classes\Platform\Service\CachedKeyChainGenerator;
+
+/**
+ * usage `sudo -u www-data php index.php 'oat\taoLti\scripts\tools\GenerateKeys'
+ *     -id 10_0 -kn Tenant_10 -pkp /platform/default/public_10.key -kp /platform/default/private_10.key`
+ */
+class GenerateKeys extends ScriptAction
+{
+    protected function provideOptions()
+    {
+        return [
+            'key_id' => [
+                'prefix' => 'id',
+                'longPrefix' => 'key_id',
+                'description' => 'Lti Platform key chain id',
+                'required' => true,
+                'cast' => 'string'
+            ],
+            'key_name' => [
+                'prefix' => 'kn',
+                'longPrefix' => 'key_name',
+                'description' => 'Lti Platform key chain name',
+                'required' => true,
+                'cast' => 'string'
+            ],
+            'public_key_path' => [
+                'prefix' => 'pkp',
+                'longPrefix' => 'public_key_path',
+                'description' => 'Lti Platform public key path',
+                'required' => true,
+                'cast' => 'string'
+            ],
+            'private_key_path' => [
+                'prefix' => 'kp',
+                'longPrefix' => 'private_key_path',
+                'description' => 'Lti Platform private key path',
+                'required' => true,
+                'cast' => 'string'
+            ],
+            'private_key_passphrase' => [
+                'prefix' => 'kpp',
+                'longPrefix' => 'private_key_passphrase',
+                'description' => 'Lti Platform private key passphrase',
+                'required' => false,
+                'cast' => 'string'
+            ],
+        ];
+    }
+
+    protected function provideDescription()
+    {
+        return 'Script to create a LTI Platform Key Chain';
+    }
+
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints the help.'
+        ];
+    }
+
+    protected function run()
+    {
+        $keyId = $this->getOption('key_id');
+        $keyName = $this->getOption('key_name');
+        $publicKeyPath = $this->getOption('public_key_path');
+        $privateKeyPath = $this->getOption('private_key_path');
+        $privateKeyPassphrase = $this->getOption('private_key_passphrase');
+
+        if (empty($keyId) || empty($keyName) || empty($publicKeyPath) || empty($privateKeyPath)) {
+            return Report::createError(
+                'Not all required arguments were provided. Try to run the script with -h option'
+            );
+        }
+        $platformKeyChainRepository = $this->getServiceLocator()->get(PlatformKeyChainRepository::SERVICE_ID);
+        $options = $platformKeyChainRepository->getOptions();
+        $option = [
+            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => $keyId,
+            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME => $keyName,
+            PlatformKeyChainRepository::OPTION_DEFAULT_PUBLIC_KEY_PATH => $publicKeyPath,
+            PlatformKeyChainRepository::OPTION_DEFAULT_PRIVATE_KEY_PATH => $privateKeyPath,
+        ];
+
+        if (!empty($privateKeyPassphrase)) {
+            $option[PlatformKeyChainRepository::OPTION_DEFAULT_PRIVATE_KEY_PASSPHRASE] = $privateKeyPassphrase;
+        }
+
+        $options[] = $option;
+        $platformKeyChainRepository->setOptions($options);
+        $this->getServiceLocator()->register(PlatformKeyChainRepository::SERVICE_ID, $platformKeyChainRepository);
+
+        /** @var CachedKeyChainGenerator $cachedKeyChainGenerator */
+        $cachedKeyChainGenerator = $this->getServiceLocator()->get(CachedKeyChainGenerator::class);
+        $cachedKeyChainGenerator->generate($keyId, $keyName, $privateKeyPassphrase);
+
+        return Report::createSuccess('LTI Platform Key Chain generated successfully!');
+    }
+}

--- a/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
@@ -69,7 +69,7 @@ class CachedKeyChainGeneratorTest extends TestCase
 
         $this->platformKeyChainRepositoryMock
             ->expects($this->once())
-            ->method('save');
+            ->method('saveKeyChain');
 
         $this->simpleCacheMock
             ->expects($this->exactly(3))

--- a/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
@@ -69,7 +69,7 @@ class CachedKeyChainGeneratorTest extends TestCase
 
         $this->platformKeyChainRepositoryMock
             ->expects($this->once())
-            ->method('save');
+            ->method('saveDefaultKeyChain');
 
         $this->simpleCacheMock
             ->expects($this->exactly(3))

--- a/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/CachedKeyChainGeneratorTest.php
@@ -69,7 +69,7 @@ class CachedKeyChainGeneratorTest extends TestCase
 
         $this->platformKeyChainRepositoryMock
             ->expects($this->once())
-            ->method('saveDefaultKeyChain');
+            ->method('save');
 
         $this->simpleCacheMock
             ->expects($this->exactly(3))

--- a/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
@@ -24,6 +24,7 @@ namespace oat\taoLti\test\unit\models\classes\Platform\Service;
 
 use oat\generis\test\TestCase;
 use oat\taoLti\models\classes\Platform\Service\OpenSslKeyChainGenerator;
+use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 
 class KeyChainGeneratorTest extends TestCase
 {
@@ -41,6 +42,22 @@ class KeyChainGeneratorTest extends TestCase
 
         $this->assertStringContainsString('-----BEGIN PRIVATE KEY-----', $result->getPrivateKey()->getContent());
         $this->assertStringContainsString('-----END PRIVATE KEY-----', $result->getPrivateKey()->getContent());
+        $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getContent());
+        $this->assertStringContainsString('-----END PUBLIC KEY-----', $result->getPublicKey()->getContent());
+    }
+
+    public function testGenerateWithPassphrase(): void
+    {
+        $result = $this->subject->generate(
+            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID,
+            PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME,
+            'pass'
+        );
+
+        $this->assertEquals('pass', $result->getPrivateKey()->getPassPhrase());
+        $this->assertEmpty($result->getPublicKey()->getPassPhrase());
+        $this->assertStringContainsString('-----BEGIN ENCRYPTED PRIVATE KEY-----', $result->getPrivateKey()->getContent());
+        $this->assertStringContainsString('-----END ENCRYPTED PRIVATE KEY-----', $result->getPrivateKey()->getContent());
         $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getContent());
         $this->assertStringContainsString('-----END PUBLIC KEY-----', $result->getPublicKey()->getContent());
     }

--- a/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
+++ b/test/unit/models/classes/Platform/Service/KeyChainGeneratorTest.php
@@ -56,8 +56,14 @@ class KeyChainGeneratorTest extends TestCase
 
         $this->assertEquals('pass', $result->getPrivateKey()->getPassPhrase());
         $this->assertEmpty($result->getPublicKey()->getPassPhrase());
-        $this->assertStringContainsString('-----BEGIN ENCRYPTED PRIVATE KEY-----', $result->getPrivateKey()->getContent());
-        $this->assertStringContainsString('-----END ENCRYPTED PRIVATE KEY-----', $result->getPrivateKey()->getContent());
+        $this->assertStringContainsString(
+            '-----BEGIN ENCRYPTED PRIVATE KEY-----',
+            $result->getPrivateKey()->getContent()
+        );
+        $this->assertStringContainsString(
+            '-----END ENCRYPTED PRIVATE KEY-----',
+            $result->getPrivateKey()->getContent()
+        );
         $this->assertStringContainsString('-----BEGIN PUBLIC KEY-----', $result->getPublicKey()->getContent());
         $this->assertStringContainsString('-----END PUBLIC KEY-----', $result->getPublicKey()->getContent());
     }

--- a/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/CachedPlatformKeyChainRepositoryTest.php
@@ -100,9 +100,9 @@ class CachedPlatformKeyChainRepositoryTest extends TestCase
 
         $this->platformKeyChainRepository
             ->expects($this->once())
-            ->method('save');
+            ->method('saveDefaultKeyChain');
 
-        $this->subject->save($keyChain);
+        $this->subject->saveDefaultKeyChain($keyChain);
     }
 
     public function testFindWhenCacheEmpty(): void
@@ -143,7 +143,9 @@ class CachedPlatformKeyChainRepositoryTest extends TestCase
 
         $this->assertSame(self::KEY_CHAIN_ID, $keyChain->getIdentifier());
         $this->assertSame('privateKey', $keyChain->getPrivateKey()->getContent());
+        $this->assertSame('pass', $keyChain->getPrivateKey()->getPassPhrase());
         $this->assertSame('publicKey', $keyChain->getPublicKey()->getContent());
+        $this->assertNull($keyChain->getPublicKey()->getPassPhrase());
     }
 
     public function testFind(): void
@@ -187,7 +189,7 @@ class CachedPlatformKeyChainRepositoryTest extends TestCase
             self::KEY_CHAIN_ID,
             self::KEY_CHAIN_NAME,
             new Key('publicKey'),
-            new Key('privateKey')
+            new Key('privateKey', 'pass')
         );
     }
 }

--- a/test/unit/models/classes/Security/DataAccess/Repository/PlatformJwksRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/PlatformJwksRepositoryTest.php
@@ -63,7 +63,7 @@ class PlatformJwksRepositoryTest extends TestCase
     public function testFind(): void
     {
         $keyChain = new KeyChain('id', 'name', new Key('123456'), new Key('654321'));
-        $collection = new KeyChainCollection(...[$keyChain]);
+        $collection = new KeyChainCollection($keyChain);
 
         $this->keyChainRepository
             ->method('findAll')

--- a/test/unit/models/classes/Security/DataAccess/Repository/PlatformKeyChainRepositoryTest.php
+++ b/test/unit/models/classes/Security/DataAccess/Repository/PlatformKeyChainRepositoryTest.php
@@ -22,16 +22,19 @@ declare(strict_types=1);
 
 namespace oat\taoLti\test\unit\models\classes\Security\DataAccess\Repository;
 
-use ErrorException;
 use oat\generis\test\ServiceManagerMockTrait;
 use OAT\Library\Lti1p3Core\Security\Key\Key;
 use OAT\Library\Lti1p3Core\Security\Key\KeyChain;
 use OAT\Library\Lti1p3Core\Security\Key\KeyChainInterface;
+use OAT\Library\Lti1p3Core\Security\Key\KeyInterface;
 use oat\oatbox\filesystem\FileSystem;
 use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\model\security\Business\Domain\Key\KeyChainQuery;
+use oat\taoLti\models\classes\Exception\PlatformKeyChainException;
 use oat\taoLti\models\classes\Security\DataAccess\Repository\PlatformKeyChainRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use oat\tao\model\security\Business\Domain\Key\Key as TaoKey;
 
 class PlatformKeyChainRepositoryTest extends TestCase
 {
@@ -51,14 +54,26 @@ class PlatformKeyChainRepositoryTest extends TestCase
         $fileSystem->method('getFileSystem')
             ->willReturn($this->fileSystem);
 
-        $this->subject = new PlatformKeyChainRepository(
+        $this->subject = new PlatformKeyChainRepository([
             [
                 PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => 'keyId',
                 PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME => 'keyName',
+                PlatformKeyChainRepository::OPTION_DEFAULT_PUBLIC_KEY_PATH => 'publicPath',
+                PlatformKeyChainRepository::OPTION_DEFAULT_PRIVATE_KEY_PATH => 'privatePath',
+            ],
+            [
+                PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => 'keyId2',
+                PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME => 'keyName2',
+                PlatformKeyChainRepository::OPTION_DEFAULT_PUBLIC_KEY_PATH => 'publicPath',
+                PlatformKeyChainRepository::OPTION_DEFAULT_PRIVATE_KEY_PATH => 'privatePath',
+            ],
+            [
+                PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => 'keyId3',
+                PlatformKeyChainRepository::OPTION_DEFAULT_KEY_NAME => 'keyName3',
                 PlatformKeyChainRepository::OPTION_DEFAULT_PUBLIC_KEY_PATH => '',
                 PlatformKeyChainRepository::OPTION_DEFAULT_PRIVATE_KEY_PATH => '',
             ]
-        );
+        ]);
         $this->subject->setServiceLocator(
             $this->getServiceManagerMock(
                 [
@@ -77,18 +92,37 @@ class PlatformKeyChainRepositoryTest extends TestCase
                 'privateKey'
             );
 
-        $keyChain = $this->subject->find('keyId');
+        $keyChain = $this->subject->find('keyId2');
 
         $this->assertInstanceOf(KeyChainInterface::class, $keyChain);
-        $this->assertEquals(
-            $keyChain = new KeyChain(
-                'keyId',
-                'keyName',
-                new Key('publicKey'),
-                new Key('privateKey')
-            ),
-            $keyChain
-        );
+        $this->assertEquals('keyId2', $keyChain->getIdentifier());
+        $this->assertEquals('keyName2', $keyChain->getKeySetName());
+        $this->assertInstanceOf(KeyInterface::class, $keyChain->getPublicKey());
+        $this->assertInstanceOf(KeyInterface::class, $keyChain->getPrivateKey());
+    }
+
+    public function testFindAll(): void
+    {
+        $this->fileSystem
+            ->method('read')
+            ->willReturnOnConsecutiveCalls(
+                'publicKey',
+                'privateKey',
+                'publicKey',
+                'privateKey',
+                '',
+                ''
+            );
+
+        $keyChains = $this->subject->findAll(new KeyChainQuery())->getKeyChains();
+
+        $this->assertIsArray($keyChains);
+        $this->assertCount(2, $keyChains);
+        $keyChain = $keyChains[1];
+        $this->assertEquals('keyId2', $keyChain->getIdentifier());
+        $this->assertEquals('keyName2', $keyChain->getName());
+        $this->assertInstanceOf(TaoKey::class, $keyChain->getPublicKey());
+        $this->assertInstanceOf(TaoKey::class, $keyChain->getPrivateKey());
     }
 
     public function testFindFails(): void
@@ -102,29 +136,37 @@ class PlatformKeyChainRepositoryTest extends TestCase
         $this->assertNull($keyChain);
     }
 
-    public function testSave(): void
+    public function testFindWithEmptyPathFails(): void
+    {
+        $this->expectException(PlatformKeyChainException::class);
+        $this->expectExceptionMessage('The key path is not defined');
+
+        $this->subject->find('keyId3');
+    }
+
+    public function testSaveDefaultKeyChain(): void
     {
         $this->fileSystem
             ->method('put')
             ->willReturn(true);
 
-        $this->subject->save(
-            new KeyChain('', '', new Key(''), new Key(''))
+        $this->subject->saveDefaultKeyChain(
+            new KeyChain('keyId', '', new Key(''), new Key(''))
         );
 
         $this->expectNotToPerformAssertions();
     }
 
-    public function testSaveFails(): void
+    public function testSaveDefaultKeyChainFails(): void
     {
         $this->fileSystem
             ->method('put')
             ->willReturn(false);
 
-        $this->expectException(ErrorException::class);
+        $this->expectException(PlatformKeyChainException::class);
         $this->expectExceptionMessage('Impossible to write LTI keys');
 
-        $this->subject->save(new KeyChain('', '', new Key(''), new Key('')));
+        $this->subject->saveDefaultKeyChain(new KeyChain('', '', new Key(''), new Key('')));
     }
 
     public function testGetDefaultKeyId(): void


### PR DESCRIPTION
## Goal 
Publish to two solar tenants

## Changelog
- feat: added support for several platform LTI providers

## How to test
1. Configure 2 tenants to one authoring
2. Add delivery configuration for 2 tenants
```
{
  "DELIVERTENANT_COUNT": "2",
  "DELIVERTENANT_1_ID": "10",
  "DELIVERTENANT_1_LABEL": "OAT TAO Solar Test Runner Stage", 
  "DELIVERTENANT_1_CUSTOMER_ID": "10",
  "DELIVERTENANT_1_LTI_1P3_AUDIENCE_URL": "https://<stack_url>",
  "DELIVERTENANT_1_LTI_1P3_CREDENTIALS_0_CLIENT_ID": "tao-deliver-id_<tenant_id>",
  "DELIVERTENANT_1_OAUTH_CREDENTIALS_0_KEY": "<Oauth_key>",
  "DELIVERTENANT_1_OAUTH_CREDENTIALS_0_SECRET": "<Oauth_secret>",
  ... //other same like DELIVERTENANT_0
}
```
3. Add platform LTI key chain for 2 tenants
```
return new PlatformKeyChainRepository([
    [
        PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => '<tenant_1>-0',
                ...
    ],
    [
        PlatformKeyChainRepository::OPTION_DEFAULT_KEY_ID => '<tenant_2>-0',
        ...
    ]
]);
```
or use the tools command to generate a key and add configuration
```
sudo -u www-data php index.php 'oat\taoLti\scripts\tools\GenerateKeys' -id 10_0 -kn Tenant_10 -pkp /platform/default/public_10.key -kp /platform/default/private_10.key
```
4. Add tests and deliver to 2 different tenants
5. In Deliveries set 'Guest Access' for this test
6. Try to run tests 