### PR TITLE
backport: MS-2756 backport to v15.15.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "oat-sa/lib-lti1p3-ags": "^1.2",
         "oat-sa/lib-lti1p3-core": "^6.0.0",
         "oat-sa/generis" : ">=15.22",
-        "oat-sa/tao-core" : ">=50.24.6"
+        "oat-sa/tao-core" : "53.15.1.1"
     },
     "autoload" : {
         "psr-4" : {

--- a/models/classes/TaoLtiSession.php
+++ b/models/classes/TaoLtiSession.php
@@ -37,14 +37,14 @@ class TaoLtiSession extends common_session_DefaultSession
     /** @var string */
     private $version = self::VERSION_LTI_1P1;
 
-    public function __construct(LtiUserInterface $user)
+    public function __construct(LtiUserInterface $user, array $contexts = [])
     {
-        parent::__construct($user);
+        parent::__construct($user, $contexts);
     }
 
-    public static function fromVersion1p3(LtiUserInterface $user): self
+    public static function fromVersion1p3(LtiUserInterface $user, array $contexts = []): self
     {
-        $session = new self($user);
+        $session = new self($user, $contexts);
 
         $session->version = self::VERSION_LTI_1P3;
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-2756

## What's Changed
- Added UserPilot to TAO 3.x.
- Backported to v15.15.0.1

## TODO 

- [x] Unit tests
- [x] E2E tests
- [x] Update composer with packages

## Dependencies PRs
- https://github.com/oat-sa/tao-core/pull/3967

## How to test
- Install TAO Portal and TAO 3.x Authoring using NGS.
- cd nextgen-stack/tao
- composer require "oat-sa/extension-tao-lti":"dev-feature/MS-2756/add-userpilot-to-tao-3.x as 15.15.1" "oat-sa/tao-core":"dev-feature/MS-2756/add-userpilot-to-tao-3.x as 54.4.1"
- Setup TAO Portal - Authoring simplification
- Login to TAO Portal
- Go to Authoring by clicking on Content Bank
- Inspect source code

## Screenshots
![image](https://github.com/oat-sa/extension-tao-lti/assets/8711268/9ebd48f3-326f-43e3-961e-7af9a30ac1ef)
