### PR TITLE
fix: add missing Reviewer role

### DIFF
--- a/install/ontology/ltiroles_membership.rdf
+++ b/install/ontology/ltiroles_membership.rdf
@@ -375,6 +375,7 @@
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetViewerRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOMedia.rdf#AssetClassNavigatorRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#BackOfficeRole"/>
+      <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#Reviewer"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#BaseUserRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#AnonymousRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#GenerisRole"/>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/SOLAR-624

## What's Changed

1. Added missing Reviewer role to LTI 1p3 Content Developer

## Dependencies PRs

## How to test
- Go to nextgen-app
- install Workflow extension
- Run the command: `docker exec -it nextgen_tao bash`
- Inside run: `php index.php '\oat\tao\scripts\SyncModels'`

- Log in TAO Portal with the user having Content Developer role
- Select “Content Bank” card
- Select an item
- Click “Submit item for review “ button

## Demo
![image (1)](https://github.com/oat-sa/extension-tao-lti/assets/10648378/5379677a-6509-4cb4-b80b-943381ef4955)

