### PR TITLE
backport: MS-2756 backport to v15.17.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "oat-sa/lib-lti1p3-ags": "^1.2",
         "oat-sa/lib-lti1p3-core": "^6.0.0",
         "oat-sa/generis" : ">=15.22",
-        "oat-sa/tao-core" : ">=50.24.6"
+        "oat-sa/tao-core" : ">=54.6.2"
     },
     "autoload" : {
         "psr-4" : {
@@ -72,5 +72,12 @@
       "psr-4" : {
         "OAT\\Library\\Lti1p3Core\\Tests\\": "../vendor/oat-sa/lib-lti1p3-core/tests/"
       }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "oat-sa/oatbox-extension-installer": true,
+            "oat-sa/composer-npm-bridge": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -72,12 +72,5 @@
       "psr-4" : {
         "OAT\\Library\\Lti1p3Core\\Tests\\": "../vendor/oat-sa/lib-lti1p3-core/tests/"
       }
-    },
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true,
-            "oat-sa/oatbox-extension-installer": true,
-            "oat-sa/composer-npm-bridge": true
-        }
     }
 }

--- a/models/classes/LtiService.php
+++ b/models/classes/LtiService.php
@@ -35,6 +35,8 @@ use oat\oatbox\log\LoggerService;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\session\SessionService;
+use oat\tao\model\session\Context\TenantDataSessionContext;
+use oat\tao\model\session\Context\UserDataSessionContext;
 use oat\tao\model\TaoOntology;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\user\Lti1p3User;
@@ -111,9 +113,26 @@ class LtiService extends ConfigurableService
 
             $ltiUser->setRegistrationId($registration->getIdentifier());
 
-            $session = TaoLtiSession::fromVersion1p3($ltiUser);
+            $contexts = [];
+            if ($clientId) {
+                $userId = $messagePayload->getUserIdentity();
+                $clientIdParts = explode('-', $clientId);
+                $contexts = [
+                    new UserDataSessionContext(
+                        $userId->getIdentifier(),
+                        $userId->getIdentifier(),
+                        $userId->getName(),
+                        $userId->getEmail(),
+                        $userId->getLocale()
+                    ),
+                    new TenantDataSessionContext(end($clientIdParts))
+                ];
+            }
+
+            $session = TaoLtiSession::fromVersion1p3($ltiUser, $contexts);
 
             $this->getServiceLocator()->propagate($session);
+
 
             return $session;
         } catch (LtiInvalidVariableException $e) {

--- a/models/classes/TaoLtiSession.php
+++ b/models/classes/TaoLtiSession.php
@@ -37,14 +37,14 @@ class TaoLtiSession extends common_session_DefaultSession
     /** @var string */
     private $version = self::VERSION_LTI_1P1;
 
-    public function __construct(LtiUserInterface $user)
+    public function __construct(LtiUserInterface $user, array $contexts = [])
     {
-        parent::__construct($user);
+        parent::__construct($user, $contexts);
     }
 
-    public static function fromVersion1p3(LtiUserInterface $user): self
+    public static function fromVersion1p3(LtiUserInterface $user, array $contexts = []): self
     {
-        $session = new self($user);
+        $session = new self($user, $contexts);
 
         $session->version = self::VERSION_LTI_1P3;
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-2756

## What's Changed
- Added UserPilot to TAO 3.x.
- Backported to 15.17.1

## TODO 

- [x] Unit tests
- [x] E2E tests
- [x] Update composer with packages

## Related PRs
- https://github.com/oat-sa/extension-tao-lti/pull/400

## Dependencies PRs
- https://github.com/oat-sa/tao-core/pull/3967

## How to test
- Install TAO Portal and TAO 3.x Authoring using NGS.
- cd nextgen-stack/tao
- composer require "oat-sa/extension-tao-lti":"dev-feature/MS-2756/add-userpilot-to-tao-3.x as 15.15.1" "oat-sa/tao-core":"dev-feature/MS-2756/add-userpilot-to-tao-3.x as 54.4.1"
- Setup TAO Portal - Authoring simplification
- Login to TAO Portal
- Go to Authoring by clicking on Content Bank
- Inspect source code

## Screenshots
![image](https://github.com/oat-sa/extension-tao-lti/assets/8711268/9ebd48f3-326f-43e3-961e-7af9a30ac1ef)