### PR TITLE
fix: Use Session to select portal theme

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,6 +30,7 @@ use oat\taoLti\models\classes\ServiceProvider\LtiServiceProvider;
 use oat\taoLti\scripts\install\CreateLti1p3RegistrationSnapshotSchema;
 use oat\taoLti\scripts\install\GenerateKeys;
 use oat\taoLti\scripts\install\GenerisSearchWhitelist;
+use oat\taoLti\scripts\install\RegisterPortalTheme;
 use oat\taoLti\scripts\install\SetupServices;
 use oat\taoLti\scripts\install\MapLtiSectionVisibility;
 use oat\taoLti\scripts\update\Updater;
@@ -66,6 +67,7 @@ return [
             MapLtiSectionVisibility::class,
             GenerisSearchWhitelist::class,
             CreateLti1p3RegistrationSnapshotSchema::class,
+            RegisterPortalTheme::class
         ]
     ],
     'update' => Updater::class,

--- a/migrations/Version202406060802293772_taoLti.php
+++ b/migrations/Version202406060802293772_taoLti.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\scripts\install\RegisterPortalTheme;
+use oat\taoQtiTest\scripts\install\RegisterQtiPackageExporter;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202406060802293772_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->runAction(new RegisterPortalTheme());
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/models/classes/theme/PortalThemeService.php
+++ b/models/classes/theme/PortalThemeService.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\theme;
+
+use common_session_SessionManager;
+use oat\tao\model\session\Context\TenantDataSessionContext;
+use oat\tao\model\theme\PortalTheme;
+use oat\tao\model\theme\ThemeService;
+use oat\taoLti\models\classes\TaoLtiSession;
+
+class PortalThemeService extends ThemeService
+{
+    public function getCurrentThemeId()
+    {
+        if ($this->isSessionFromPortal()) {
+            return PortalTheme::THEME_ID;
+        }
+
+        return $this->getOption(static::OPTION_CURRENT);
+    }
+
+    private function isSessionFromPortal(): bool
+    {
+        $session = common_session_SessionManager::getSession();
+        return $session instanceof TaoLtiSession
+            && !empty($session->getContexts(TenantDataSessionContext::class));
+    }
+}

--- a/scripts/install/RegisterPortalTheme.php
+++ b/scripts/install/RegisterPortalTheme.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\scripts\install;
+
+use oat\oatbox\config\ConfigurationService;
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\theme\PortalTheme;
+use oat\tao\model\theme\ThemeServiceInterface;
+use oat\taoLti\models\classes\theme\PortalThemeService;
+
+class RegisterPortalTheme extends InstallAction
+{
+    public function __invoke($params = [])
+    {
+        /** @var ConfigurationService $previousThemeService */
+        $previousThemeService = $this->getServiceLocator()->get(ThemeServiceInterface::SERVICE_ID);
+
+        /** @var ThemeServiceInterface $service */
+        $service = new PortalThemeService();
+        $service->setOptions($previousThemeService->getOptions());
+        $service->addTheme(new PortalTheme(), false);
+
+        $this->getServiceLocator()->register(ThemeServiceInterface::SERVICE_ID, $service);
+    }
+}

--- a/scripts/install/RegisterPortalTheme.php
+++ b/scripts/install/RegisterPortalTheme.php
@@ -33,13 +33,13 @@ class RegisterPortalTheme extends InstallAction
     public function __invoke($params = [])
     {
         /** @var ConfigurationService $previousThemeService */
-        $previousThemeService = $this->getServiceLocator()->get(ThemeServiceInterface::SERVICE_ID);
+        $previousThemeService = $this->getServiceManager()->get(ThemeServiceInterface::SERVICE_ID);
 
         /** @var ThemeServiceInterface $service */
-        $service = new PortalThemeService();
+        $service = $this->propagate(new PortalThemeService());
         $service->setOptions($previousThemeService->getOptions());
         $service->addTheme(new PortalTheme(), false);
 
-        $this->getServiceLocator()->register(ThemeServiceInterface::SERVICE_ID, $service);
+        $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $service);
     }
 }


### PR DESCRIPTION
When user access to Tao 3.x from Tao Portal Tao will have back button that will lead back to Tao Portal
When user login using Tao login page we will use regular Tao Theme


https://github.com/oat-sa/extension-tao-lti/assets/16231681/05fd8d51-361c-4586-9323-d14dc3e6e98a


https://github.com/oat-sa/extension-tao-lti/assets/16231681/db12ca85-06df-4365-8ef4-8ccafbe5274e

