### PR TITLE
fix: remove RegisterPortalTheme introduction

### DIFF
--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -102,12 +102,6 @@ class AuthoringTool extends ToolModule
             ->get(LtiService::class)
             ->startLti1p3Session($ltiMessage, $user);
 
-        $this->getServiceLocator()
-            ->getContainer()
-            ->get(ThemeService::SERVICE_ID)
-            ->setCurrentTheme('portal');
-
-
         $this->forward('run', null, null, $_GET);
     }
 

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -28,6 +28,7 @@ use core_kernel_classes_Resource;
 use helpers_Random;
 use InterruptedActionException;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
+use oat\tao\model\theme\ThemeService;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\taoLti\models\classes\LtiService;
@@ -100,6 +101,12 @@ class AuthoringTool extends ToolModule
             ->getContainer()
             ->get(LtiService::class)
             ->startLti1p3Session($ltiMessage, $user);
+
+        $this->getServiceLocator()
+            ->getContainer()
+            ->get(ThemeService::SERVICE_ID)
+            ->setCurrentTheme('portal');
+
 
         $this->forward('run', null, null, $_GET);
     }

--- a/manifest.php
+++ b/manifest.php
@@ -19,10 +19,8 @@
  * Copyright (c) 2013-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
-use oat\ltiTestReview\controller\Review;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
-use oat\taoLti\controller\AuthoringTool;
 use oat\taoLti\controller\CookieUtils;
 use oat\taoLti\controller\Security;
 use oat\taoLti\models\classes\LtiRoles;
@@ -30,7 +28,7 @@ use oat\taoLti\models\classes\ServiceProvider\LtiServiceProvider;
 use oat\taoLti\scripts\install\CreateLti1p3RegistrationSnapshotSchema;
 use oat\taoLti\scripts\install\GenerateKeys;
 use oat\taoLti\scripts\install\GenerisSearchWhitelist;
-use oat\taoLti\scripts\install\RegisterPortalTheme;
+use oat\taoLti\scripts\install\RegisterPortalThemeDetailProvider;
 use oat\taoLti\scripts\install\SetupServices;
 use oat\taoLti\scripts\install\MapLtiSectionVisibility;
 use oat\taoLti\scripts\update\Updater;
@@ -67,6 +65,7 @@ return [
             MapLtiSectionVisibility::class,
             GenerisSearchWhitelist::class,
             CreateLti1p3RegistrationSnapshotSchema::class,
+            RegisterPortalThemeDetailProvider::class,
         ]
     ],
     'update' => Updater::class,

--- a/manifest.php
+++ b/manifest.php
@@ -67,7 +67,6 @@ return [
             MapLtiSectionVisibility::class,
             GenerisSearchWhitelist::class,
             CreateLti1p3RegistrationSnapshotSchema::class,
-            RegisterPortalTheme::class
         ]
     ],
     'update' => Updater::class,

--- a/migrations/Version202406060802293772_taoLti.php
+++ b/migrations/Version202406060802293772_taoLti.php
@@ -23,7 +23,7 @@ final class Version202406060802293772_taoLti extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->runAction(new RegisterPortalTheme());
+        // Action removed due to conflicting with multiple instance implementations.
     }
 
     public function down(Schema $schema): void

--- a/migrations/Version202406101417393772_taoLti.php
+++ b/migrations/Version202406101417393772_taoLti.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoLti\scripts\install\RegisterPortalTheme;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202406101417393772_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'This will revert change introduced in Version202406060802293772_taoLti.php for instances 
+        with taoStyle enabled.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->runAction(new RegisterPortalTheme());
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/migrations/Version202406101417393772_taoLti.php
+++ b/migrations/Version202406101417393772_taoLti.php
@@ -7,6 +7,7 @@ namespace oat\taoLti\migrations;
 use Doctrine\DBAL\Schema\Schema;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\taoLti\scripts\install\RegisterPortalTheme;
+use oat\taoLti\scripts\install\UnregisterLtiPortalTheme;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
@@ -23,7 +24,7 @@ final class Version202406101417393772_taoLti extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->runAction(new RegisterPortalTheme());
+        $this->runAction(new UnregisterLtiPortalTheme());
     }
 
     public function down(Schema $schema): void

--- a/models/classes/theme/PortalThemeDetailProvider.php
+++ b/models/classes/theme/PortalThemeDetailProvider.php
@@ -37,8 +37,7 @@ class PortalThemeDetailProvider implements ThemeDetailsProviderInterface
             return PortalTheme::THEME_ID;
         };
 
-        $defaultTheme = new DefaultTheme();
-        return $defaultTheme->getId();
+        return '';
     }
 
     /**

--- a/models/classes/theme/PortalThemeDetailProvider.php
+++ b/models/classes/theme/PortalThemeDetailProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\models\classes\theme;
+
+use common_session_SessionManager as SessionManager;
+use oat\tao\model\session\Context\TenantDataSessionContext;
+use oat\tao\model\theme\DefaultTheme;
+use oat\tao\model\theme\PortalTheme;
+use oat\tao\model\theme\ThemeDetailsProviderInterface;
+use oat\taoLti\models\classes\TaoLtiSession;
+
+class PortalThemeDetailProvider implements ThemeDetailsProviderInterface
+{
+    public function getThemeId(): string
+    {
+        if ($this->isSessionFromPortal()) {
+            return PortalTheme::THEME_ID;
+        };
+
+        $defaultTheme = new DefaultTheme();
+        return $defaultTheme->getId();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHeadless(): bool
+    {
+        return false;
+    }
+
+    private function isSessionFromPortal(): bool
+    {
+        $session = SessionManager::getSession();
+        return $session instanceof TaoLtiSession
+            && !empty($session->getContexts(TenantDataSessionContext::class));
+    }
+}

--- a/scripts/install/RegisterPortalThemeDetailProvider.php
+++ b/scripts/install/RegisterPortalThemeDetailProvider.php
@@ -22,24 +22,17 @@ declare(strict_types=1);
 
 namespace oat\taoLti\scripts\install;
 
-use oat\oatbox\config\ConfigurationService;
 use oat\oatbox\extension\InstallAction;
-use oat\tao\model\theme\PortalTheme;
 use oat\tao\model\theme\ThemeServiceInterface;
-use oat\taoLti\models\classes\theme\PortalThemeService;
 
-class RegisterPortalTheme extends InstallAction
+class RegisterPortalThemeDetailProvider extends InstallAction
 {
-    public function __invoke($params = [])
+    public function __invoke($params)
     {
-        /** @var ConfigurationService $previousThemeService */
-        $previousThemeService = $this->getServiceManager()->get(ThemeServiceInterface::SERVICE_ID);
-
-        /** @var ThemeServiceInterface $service */
-        $service = $this->propagate(new PortalThemeService());
-        $service->setOptions($previousThemeService->getOptions());
-        $service->addTheme(new PortalTheme(), false);
-
-        $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $service);
+        $service = $this->getServiceManager()->get(ThemeServiceInterface::SERVICE_ID);
+        $themeDetailsProviders = $service->getOption('themeDetailsProviders');
+        $themeDetailsProviders[] = new \oat\taoLti\models\classes\theme\PortalThemeDetailProvider();
+        $service->setOption('themeDetailsProviders', $themeDetailsProviders);
+        $this->registerService(ThemeServiceInterface::SERVICE_ID, $service);
     }
 }

--- a/scripts/install/UnregisterLtiPortalTheme.php
+++ b/scripts/install/UnregisterLtiPortalTheme.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLti\scripts\install;
+
+use common_ext_ExtensionsManager;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\theme\ThemeServiceInterface;
+use oat\taoDelivery\scripts\install\installDeliveryFields;
+use oat\taoStyles\model\service\PersistenceThemeService;
+
+class UnregisterLtiPortalTheme extends installDeliveryFields
+{
+    public function __invoke($params = [])
+    {
+        /** @var ThemeServiceInterface|ConfigurableService $service */
+        $service = $this->getServiceManager()->get(ThemeServiceInterface::SERVICE_ID);
+        $oldConfig = $service->getOptions();
+        /** @var common_ext_ExtensionsManager $extManager */
+        $extManager = $this->getServiceManager()->get(common_ext_ExtensionsManager::class);
+        if ($extManager->isInstalled('taoStyles')) {
+            $revertedService = $this->propagate(new PersistenceThemeService($oldConfig));
+            $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $revertedService);
+        }
+    }
+}

--- a/scripts/install/UnregisterLtiPortalTheme.php
+++ b/scripts/install/UnregisterLtiPortalTheme.php
@@ -69,7 +69,7 @@ class UnregisterLtiPortalTheme extends InstallAction
         }
 
         //Make sure current theme is set
-        if (!isset($oldConfig['current'])) {
+        if (!isset($oldConfig['current']) && !($service instanceof PersistenceThemeService)) {
             $oldConfig = $this->defineCurrent($oldConfig);
         }
 

--- a/scripts/install/UnregisterLtiPortalTheme.php
+++ b/scripts/install/UnregisterLtiPortalTheme.php
@@ -24,17 +24,17 @@ namespace oat\taoLti\scripts\install;
 
 use common_ext_ExtensionsManager;
 use Exception;
+use oat\oatbox\extension\InstallAction;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\theme\DefaultTheme;
 use oat\tao\model\theme\PortalTheme;
 use oat\tao\model\theme\ThemeService;
 use oat\tao\model\theme\ThemeServiceInterface;
-use oat\taoDelivery\scripts\install\installDeliveryFields;
 use oat\taoLti\models\classes\theme\PortalThemeDetailProvider;
 use oat\taoLti\models\classes\theme\PortalThemeService;
 use oat\taoStyles\model\service\PersistenceThemeService;
 
-class UnregisterLtiPortalTheme extends installDeliveryFields
+class UnregisterLtiPortalTheme extends InstallAction
 {
     public function __invoke($params = [])
     {

--- a/scripts/install/UnregisterLtiPortalTheme.php
+++ b/scripts/install/UnregisterLtiPortalTheme.php
@@ -24,6 +24,8 @@ namespace oat\taoLti\scripts\install;
 
 use common_ext_ExtensionsManager;
 use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\theme\DefaultTheme;
+use oat\tao\model\theme\PortalTheme;
 use oat\tao\model\theme\ThemeServiceInterface;
 use oat\taoDelivery\scripts\install\installDeliveryFields;
 use oat\taoStyles\model\service\PersistenceThemeService;
@@ -38,8 +40,19 @@ class UnregisterLtiPortalTheme extends installDeliveryFields
         /** @var common_ext_ExtensionsManager $extManager */
         $extManager = $this->getServiceManager()->get(common_ext_ExtensionsManager::class);
         if ($extManager->isInstalled('taoStyles')) {
+            unset($oldConfig['available']);
             $revertedService = $this->propagate(new PersistenceThemeService($oldConfig));
             $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $revertedService);
+            $revertedService->addTheme(new PortalTheme(), false);
+            $revertedService->addTheme(new DefaultTheme(), false);
+            return;
         }
+
+        //Make sure current theme is set
+        if (!isset($oldConfig['current'])) {
+            $oldConfig['current'] = 'default';
+        }
+
+        $service->setOptions($oldConfig);
     }
 }

--- a/scripts/install/UnregisterLtiPortalTheme.php
+++ b/scripts/install/UnregisterLtiPortalTheme.php
@@ -28,6 +28,7 @@ use oat\tao\model\theme\DefaultTheme;
 use oat\tao\model\theme\PortalTheme;
 use oat\tao\model\theme\ThemeServiceInterface;
 use oat\taoDelivery\scripts\install\installDeliveryFields;
+use oat\taoLti\models\classes\theme\PortalThemeDetailProvider;
 use oat\taoStyles\model\service\PersistenceThemeService;
 
 class UnregisterLtiPortalTheme extends installDeliveryFields
@@ -41,10 +42,14 @@ class UnregisterLtiPortalTheme extends installDeliveryFields
         $extManager = $this->getServiceManager()->get(common_ext_ExtensionsManager::class);
         if ($extManager->isInstalled('taoStyles')) {
             unset($oldConfig['available']);
+            $oldConfig['themeDetailsProviders'] = [
+                new PortalThemeDetailProvider()
+            ];
             $revertedService = $this->propagate(new PersistenceThemeService($oldConfig));
             $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $revertedService);
             $revertedService->addTheme(new PortalTheme(), false);
             $revertedService->addTheme(new DefaultTheme(), false);
+
             return;
         }
 

--- a/scripts/install/UnregisterLtiPortalTheme.php
+++ b/scripts/install/UnregisterLtiPortalTheme.php
@@ -41,6 +41,14 @@ class UnregisterLtiPortalTheme extends InstallAction
         /** @var ThemeServiceInterface|ConfigurableService $service */
         $service = $this->getServiceManager()->get(ThemeServiceInterface::SERVICE_ID);
         $oldConfig = $service->getOptions();
+
+        //This provider will allow to display Portal Theme
+        if (!isset($oldConfig['themeDetailsProviders'])) {
+            $oldConfig['themeDetailsProviders'] = [
+                new PortalThemeDetailProvider()
+            ];
+        }
+
         /** @var common_ext_ExtensionsManager $extManager */
         $extManager = $this->getServiceManager()->get(common_ext_ExtensionsManager::class);
         //If taoStyles is installed, we had PersistenceThemeService used as theming.conf.php and we should still use it
@@ -51,10 +59,7 @@ class UnregisterLtiPortalTheme extends InstallAction
                 $this->getLogger()->error($e->getMessage());
                 return;
             }
-            //This provider will allow to display Portal Theme
-            $oldConfig['themeDetailsProviders'] = [
-                new PortalThemeDetailProvider()
-            ];
+
             $revertedService = $this->propagate(new PersistenceThemeService($oldConfig));
             $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $revertedService);
             $revertedService->addTheme(new PortalTheme(), false);
@@ -74,6 +79,7 @@ class UnregisterLtiPortalTheme extends InstallAction
         }
 
         $service->setOptions($oldConfig);
+        $this->getServiceManager()->register(ThemeServiceInterface::SERVICE_ID, $service);
     }
 
     private function defineCurrent(array $config): array


### PR DESCRIPTION
This Registration cannot be executed on instances that are using `\oat\taoStyles\model\service\PersistenceThemeService`. 
PersistenceThemeService violates `\oat\tao\model\theme\ThemeServiceInterface`.