### PR TITLE
fix: use getLaunchPresentation language in Authoring

### DIFF
--- a/models/classes/LtiService.php
+++ b/models/classes/LtiService.php
@@ -28,6 +28,7 @@ use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use oat\generis\model\GenerisRdf;
+use OAT\Library\Lti1p3Core\Message\Payload\Claim\LaunchPresentationClaim;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Message\Payload\MessagePayloadInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
@@ -124,7 +125,7 @@ class LtiService extends ConfigurableService
                         $userId->getIdentifier(),
                         $userId->getName(),
                         $userId->getEmail(),
-                        $userId->getLocale() ?? $messagePayload->getLaunchPresentation()->getLocale()
+                        $userId->getLocale() ?? $this->getLocaleFromMessagePayload($messagePayload)
                     ),
                     new TenantDataSessionContext(end($clientIdParts))
                 ];
@@ -231,5 +232,14 @@ class LtiService extends ConfigurableService
     public static function singleton()
     {
         return ServiceManager::getServiceManager()->get(static::class);
+    }
+
+    private function getLocaleFromMessagePayload(LtiMessagePayloadInterface $messagePayload): ?string
+    {
+        if ($messagePayload && $messagePayload->getLaunchPresentation() instanceof LaunchPresentationClaim) {
+            return $messagePayload->getLaunchPresentation()->getLocale();
+        }
+
+        return null;
     }
 }

--- a/models/classes/LtiService.php
+++ b/models/classes/LtiService.php
@@ -105,6 +105,7 @@ class LtiService extends ConfigurableService
                 $ltiUser->setUserFirstTimeUri(GenerisRdf::GENERIS_FALSE);
                 $ltiUser->setUserLatestExtension(self::DEFAULT_USER_EXTENSION);
 
+
                 $userLatestExtensionValue = (string)$user->getOnePropertyValue($userLatestExtension);
                 if (!empty($userLatestExtensionValue)) {
                     $ltiUser->setUserLatestExtension($userLatestExtensionValue);
@@ -123,7 +124,7 @@ class LtiService extends ConfigurableService
                         $userId->getIdentifier(),
                         $userId->getName(),
                         $userId->getEmail(),
-                        $userId->getLocale()
+                        $userId->getLocale() ?? $messagePayload->getLaunchPresentation()->getLocale()
                     ),
                     new TenantDataSessionContext(end($clientIdParts))
                 ];

--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -102,6 +102,7 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             [
                 'help' => self::PORTAL_ACCESS_ROLES,
                 'settings_my_password' => self::PORTAL_ACCESS_ROLES,
+                'settings_my_settings' => self::PORTAL_ACCESS_ROLES
             ]
         );
 


### PR DESCRIPTION
How to test:

1. In portal change user language to non English
2. Go to Content Bank
3. When redirected to Tao 3.x make sure language change has been applied
4. Make sure `My Settings` field is not visible
5. Logout button available under user name

https://github.com/oat-sa/extension-tao-lti/assets/16231681/bb55b34a-51e3-4235-83fd-76e7dc9c8494

![Screenshot 2024-06-13 at 16 26 37](https://github.com/oat-sa/extension-tao-lti/assets/16231681/81fb3d49-577d-4797-ad49-230b5d390778)

Required changes in tao-core
https://github.com/oat-sa/tao-core/pull/4045