### PR TITLE
fix: Use an HTTP 301 redirect for internal redirects initiated by LTI logins

### DIFF
--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -45,6 +45,8 @@ class AuthoringTool extends ToolModule
     private const LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE = 'No matching registration found tool side';
 
     /**
+     * @deprecated LTI requests to open Authoring should come through launch().
+     *
      * @throws LtiException
      * @throws InterruptedActionException
      * @throws common_exception_Error

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -68,8 +68,6 @@ class AuthoringTool extends ToolModule
      */
     protected function getValidatedLtiMessagePayload(): LtiMessagePayloadInterface
     {
-        \common_Logger::w(self::class . '::getValidatedLtiMessagePayload');
-
         return $this->getServiceLocator()
             ->getContainer()
             ->get(Lti1p3Validator::class . 'Authoring')
@@ -100,7 +98,6 @@ class AuthoringTool extends ToolModule
 
             $this->getLtiService()->startLti1p3Session($ltiMessage, $user);
         } catch (LtiException $exception) {
-            $this->getLogger()->warning('Caught LtiException',);
             $this->handleLtiException($exception);
         }
 

--- a/controller/AuthoringTool.php
+++ b/controller/AuthoringTool.php
@@ -82,6 +82,9 @@ class AuthoringTool extends ToolModule
      * @throws NotFoundExceptionInterface
      * @throws common_exception_Error
      * @throws WrongLtiRolesException
+     * @throws core_kernel_users_Exception
+     *
+     * @return never
      */
     public function launch(): void
     {
@@ -107,23 +110,27 @@ class AuthoringTool extends ToolModule
     }
 
     /**
+     * Handles an exception, either by rethrowing it or by throwing an instance of
+     * InterruptedActionException in order to redirect the user to the login page.
+     *
      * @throws InterruptedActionException
      * @throws LtiException
+     * @return never
      */
     private function handleLtiException(LtiException $exception): void
     {
-        if ($exception->getMessage() === self::LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE) {
-            $this->getLogger()->warning(
-                sprintf(
-                    'Missing registration for current audience. Redirecting to the login page. Exception: %s',
-                    $exception
-                )
-            );
-
-            $this->redirect(_url('login', 'Main', 'tao'));  // throws
+        if ($exception->getMessage() !== self::LTI_NO_MATCHING_REGISTRATION_FOUND_MESSAGE) {
+            throw $exception;
         }
 
-        throw $exception;
+        $this->getLogger()->warning(
+            sprintf(
+                'Missing registration for current audience. Redirecting to the login page. Exception: %s',
+                $exception
+            )
+        );
+
+        $this->redirect(_url('login', 'Main', 'tao'));
     }
 
     /**


### PR DESCRIPTION
**Associated Jira issue:** [SOLAR-668](https://oat-sa.atlassian.net/browse/SOLAR-668)

When a user clicks on the link from Portal to go into TAO 3.x, Portal redirects the user to https://backoffice.host/taoLti/AuthoringTool/launch with an LTI payload with a short expiration time. That payload is expected to be used only once.

In turn, when this request hits TAO 3.x, the `launch()` action validates the payload and security constraints, starts a user session and forwards its processing to the `run()` method in the same controller (`$this->forward()`). When `run()` is called, it checks if the user session just created by `launch()` is valid, and then issues an HTTP redirect (`redirect()`).

This redirect happens to be sent to the client as a a generic `HTTP 302 Found` response, which is meant to _indicate that the target resource resides temporarily under a different URI_ and, _since the redirection might be altered on occasion_, expects the browser to _continue to use the target URI for future requests_ [[ref](https://www.rfc-editor.org/rfc/rfc9110#status.302)]. That means the 302 redirect makes the browser to keep the intermediate URL returning the redirect itself as part of the "normal flow": The URL for the controller that validates the request coming from Portal is kept in the browser history, as it _might be altered on occasion_.

Changes in this PR make that intermediate _jump_ from the authentication logic (`launch()`) into Authoring itself (`run()`) to be issued as an `HTTP 301 Moved Permanently` redirect instead, which makes _any future references_ to the intermediate URL to _use one of the enclosed URIs_ [[ref](https://www.rfc-editor.org/rfc/rfc9110#status.301)]. That means the intermediate redirect is permanent, and the browser shall use the target URL for the redirect instead of the intermediate one. The net effect of this is that the intermediate URL (`launch()`) is not part of the "normal flow" anymore, so it is not kept in the browser history: Clicking the "back button" goes back to Portal.

There's also another intermediate request to the Auth server to get a token used for the LTI launch; however, that one is handled within the Javascript code and therefore it's not captured in the browser history.

Note the previous URL will be http://portal.host/content-bank, meaning clicking on the back button will bounce the user back to TAO 3.x. That is to be fixed at the Portal FE.

**Related PR:**
- https://github.com/oat-sa/tao-portal/pull/1091

[SOLAR-668]: https://oat-sa.atlassian.net/browse/SOLAR-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ