### PR TITLE
fix: add missed role ItemAuthor fro LTI Users

### DIFF
--- a/install/ontology/ltiroles_membership.rdf
+++ b/install/ontology/ltiroles_membership.rdf
@@ -398,6 +398,7 @@
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiTestPreviewerRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#RestrictedItemAuthor"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#AbstractItemAuthor"/>
+      <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemAuthor"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemClassNavigatorRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemClassEditorRole"/>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemClassCreatorRole"/>

--- a/migrations/Version202408231119303772_taoLti.php
+++ b/migrations/Version202408231119303772_taoLti.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoLti\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202408231119303772_taoLti extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missed ItemAuthor role for LTI users';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+    }
+
+}


### PR DESCRIPTION
Added `http://www.tao.lu/Ontologies/TAOItem.rdf#ItemAuthor` from LTI users to be able to edit response declarations using XML editor

How to test:

1. Install TAO 3.x with `xmlEditRp` extension
2. Setup Portal for using TAO 3.x as `Content Bank`
3. Create a user on portal with the `Content editor` role
4. Login by this user on Portal
5. Go to `Content bank` from the portal
6. Create an item with the custom response processing
7. Open `Edit Processing Rule`
8. Try to update XML

<img width="245" alt="image" src="https://github.com/user-attachments/assets/7fafa69a-6a90-4987-99ae-2b27124bc1c7">
