### PR TITLE
feat!: upgrade oat-sa/lib-lti1p3-* libraries

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.4', '8.0', '8.1' ]
+        php-version: [ '8.1', '8.2', '8.3' ]
         include:
-          - php-version: '8.1'
+          - php-version: '8.3'
             coverage: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     	"tao-extension-name" : "taoLti"
     },
     "require": {
+        "php": "~8",
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",

--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,9 @@
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/lib-lti1p3-ags": "^1.2",
-        "oat-sa/lib-lti1p3-core": "^6.0.0",
-        "oat-sa/generis" : ">=15.22",
+        "oat-sa/lib-lti1p3-ags": "~2",
+        "oat-sa/lib-lti1p3-core": "~7",
+        "oat-sa/generis" : ">=15.40.0",
         "oat-sa/tao-core" : ">=54.10.0"
     },
     "autoload" : {


### PR DESCRIPTION
This PR upgrades the `oat-sa/lib-lti1p3-*` to the latest ones

⚠️ DO NOT MERGE until it's confirmed that the deployment stacks support PHP 8 and higher ⚠️ 

## Dependencies
- [x] https://github.com/oat-sa/generis/pull/1141