### PR TITLE
fix: remove my_settings from params for SectionVisibilityByRoleFilter

### DIFF
--- a/models/classes/ServiceProvider/LtiServiceProvider.php
+++ b/models/classes/ServiceProvider/LtiServiceProvider.php
@@ -103,7 +103,6 @@ class LtiServiceProvider implements ContainerServiceProviderInterface
             [
                 'help' => self::PORTAL_ACCESS_ROLES,
                 'settings_my_password' => self::PORTAL_ACCESS_ROLES,
-                'settings_my_settings' => self::PORTAL_ACCESS_ROLES
             ]
         );
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4130

## What's Changed

- Show My settings menu when login from Portal to backoffice

## How to test
- Login to Portal then click Content Bank to be logged into backoffice
- Check right top drop down menu, My Settings is visible

## Video

https://github.com/user-attachments/assets/48b889ba-d570-4eb6-a947-af6e34f5ef02

