### PR TITLE
ACL Roles Class Used for Permission Assigment

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -34,6 +34,7 @@ $todefine = [
     'PROPERTY_USER_LTICONSUMER'     => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#UserConsumer',
 
     'CLASS_LTI_ROLES'               => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole',
+    'CLASS_ACL_ROLES'               => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#ACLRole',
     'PROPERTY_LTI_ROLES_URN'        => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#RoleURN',
 
     'CLASS_LTI_TOOL'                => 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LTITool',

--- a/install/ontology/ltiroles_membership.rdf
+++ b/install/ontology/ltiroles_membership.rdf
@@ -52,7 +52,7 @@
     <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership#Learner">
-      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole"/>
+      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#AclRole"/>
       <rdfs:label xml:lang="en-US"><![CDATA[LTI 1p3 Learner]]></rdfs:label>
       <rdfs:comment xml:lang="en-US"><![CDATA[The LTI 1p3 Context Learner Role]]></rdfs:comment>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiBaseRole"/>
@@ -187,7 +187,7 @@
       <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor">
-      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole"/>
+      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#AclRole"/>
       <rdfs:label xml:lang="en-US"><![CDATA[LTI 1p3 Instructor]]></rdfs:label>
       <rdfs:comment xml:lang="en-US"><![CDATA[The LTI 1p3 Context Instructor Role]]></rdfs:comment>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiBaseRole"/>
@@ -293,7 +293,7 @@
       <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Developer">
-      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole"/>
+      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#AclRole"/>
       <rdfs:label xml:lang="en-US"><![CDATA[LTI 1p3 Developer]]></rdfs:label>
       <rdfs:comment xml:lang="en-US"><![CDATA[The LTI 1p3 Context Developer Role]]></rdfs:comment>
       <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#GenerisRole"/>
@@ -381,7 +381,7 @@
       <generis:isSystem rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper">
-      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole"/>
+      <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOLTI.rdf#AclRole"/>
       <rdfs:label xml:lang="en-US"><![CDATA[LTI 1p3 Content Developer]]></rdfs:label>
       <rdfs:comment xml:lang="en-US"><![CDATA[The LTI 1p3 Context Content Developer Role]]></rdfs:comment>
       <generis:includesRole rdf:resource="http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper"/>

--- a/install/ontology/roledefinition.rdf
+++ b/install/ontology/roledefinition.rdf
@@ -10,7 +10,12 @@
     <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#ClassRole"/>
     <rdfs:label xml:lang="en-US"><![CDATA[LTI Roles]]></rdfs:label>
   </rdf:Description>
-  
+
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#AclRole">
+    <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#ClassRole"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[ACL Roles]]></rdfs:label>
+  </rdf:Description>
+
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOLTI.rdf#RoleURN">
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
     <rdfs:label xml:lang="en-US"><![CDATA[URN]]></rdfs:label>

--- a/models/classes/LtiRoles.php
+++ b/models/classes/LtiRoles.php
@@ -30,6 +30,8 @@ interface LtiRoles
 {
     public const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIRole';
 
+    public const ACL_CLASS_URI = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#AclRole';
+
     public const PROPERTY_URN = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#RoleURN';
 
     public const INSTANCE_LTI_BASE = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LtiBaseRole';


### PR DESCRIPTION
This pull request introduces a new `AclRole` class to the ontology for LTI roles and updates the relevant code and RDF definitions to use this new class for role typing. The changes help distinguish ACL roles from standard LTI roles and provide a clearer ontology structure for role management.

**Ontology and RDF schema updates:**

* Added the `AclRole` class as a subclass of `ClassRole` in `roledefinition.rdf`, including a label for clarity.
* Updated all LTI role instances in `ltiroles_membership.rdf` (such as Learner, Instructor, Developer, Content Developer) to use `AclRole` instead of `LTIRole` as their RDF type.

**Code and constant updates:**

* Introduced the `CLASS_ACL_ROLES` constant in `constants.php` to reference the new `AclRole` class URI.
* Added `ACL_CLASS_URI` constant to the `LtiRoles` interface in `LtiRoles.php` for use in code referencing the new class.